### PR TITLE
[volume-4] 동시성 이슈 제어 및 쿠폰 기능 추가

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/order/DiscountProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/DiscountProcessor.java
@@ -1,0 +1,25 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.coupon.CouponCommand;
+import com.loopers.domain.coupon.CouponService;
+import com.loopers.domain.coupon.UserCouponInfo;
+import java.math.BigDecimal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DiscountProcessor {
+
+    private final CouponService couponService;
+
+    public BigDecimal applyDiscount(Long couponId, Long userId, BigDecimal originalAmount) {
+        BigDecimal paymentAmount = originalAmount;
+
+        if (couponId != null) {
+            UserCouponInfo.Use useInfo = couponService.use(new CouponCommand.Use(couponId, userId, originalAmount));
+            paymentAmount = useInfo.paymentAmount();
+        }
+        return paymentAmount;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCriteria.java
@@ -4,6 +4,7 @@ import com.loopers.domain.order.OrderCommand;
 import com.loopers.domain.stock.StockCommand;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
 public class OrderCriteria {
     public record Order(
@@ -15,6 +16,16 @@ public class OrderCriteria {
         public OrderCommand.Order toOrderCommandWith(List<OrderCommand.Line> lines,
                                                      BigDecimal originalAmount, BigDecimal paymentAmount) {
             return new OrderCommand.Order(userId, lines, toCommandDelivery(), originalAmount, paymentAmount);
+        }
+
+        public List<OrderCommand.Line> toCommandLines(Map<Long, BigDecimal> productPriceMap) {
+            return lines.stream()
+                    .map(line -> new OrderCommand.Line(
+                            line.productId(),
+                            line.quantity(),
+                            productPriceMap.get(line.productId()).multiply(BigDecimal.valueOf(line.quantity()))
+                    ))
+                    .toList();
         }
 
         public OrderCommand.Delivery toCommandDelivery() {

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCriteria.java
@@ -2,16 +2,19 @@ package com.loopers.application.order;
 
 import com.loopers.domain.order.OrderCommand;
 import com.loopers.domain.stock.StockCommand;
+import java.math.BigDecimal;
 import java.util.List;
 
 public class OrderCriteria {
     public record Order(
             Long userId,
             List<Line> lines,
-            Delivery delivery
+            Delivery delivery,
+            Long couponId
     ) {
-        public OrderCommand.Order toOrderCommandWith(List<OrderCommand.Line> lines) {
-            return new OrderCommand.Order(userId, lines, toCommandDelivery());
+        public OrderCommand.Order toOrderCommandWith(List<OrderCommand.Line> lines,
+                                                     BigDecimal originalAmount, BigDecimal paymentAmount) {
+            return new OrderCommand.Order(userId, lines, toCommandDelivery(), originalAmount, paymentAmount);
         }
 
         public OrderCommand.Delivery toCommandDelivery() {

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,27 +1,15 @@
 package com.loopers.application.order;
 
-import com.loopers.domain.coupon.CouponCommand;
-import com.loopers.domain.coupon.CouponService;
 import com.loopers.domain.order.OrderCommand;
 import com.loopers.domain.order.OrderInfo;
 import com.loopers.domain.order.OrderService;
 import com.loopers.domain.point.PointCommand;
-import com.loopers.domain.point.PointService;
-import com.loopers.domain.product.ProductCommand;
-import com.loopers.domain.product.ProductInfo;
-import com.loopers.domain.product.ProductService;
-import com.loopers.domain.stock.StockService;
 import com.loopers.domain.user.UserCommand;
 import com.loopers.domain.user.UserInfo;
 import com.loopers.domain.user.UserService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,11 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderFacade {
 
     private final UserService userService;
-    private final ProductService productService;
-    private final CouponService couponService;
     private final OrderService orderService;
-    private final StockService stockService;
-    private final PointService pointService;
+    private final OrderProcessor orderProcessor;
+    private final PaymentProcessor paymentProcessor;
 
     @Transactional
     public OrderResult order(OrderCriteria.Order criteria) {
@@ -44,34 +30,9 @@ public class OrderFacade {
             throw new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다.");
         }
 
-        Set<Long> productIds = criteria.lines().stream().map(OrderCriteria.Line::productId).collect(Collectors.toSet());
-
-        Map<Long, ProductInfo> productInfos = productService.getPurchasableProducts(new ProductCommand.GetProducts(productIds))
-                .stream()
-                .collect(Collectors.toMap(ProductInfo::id, product -> product));
-        if (productInfos.size() != productIds.size()) {
-            throw new CoreException(ErrorType.NOT_FOUND, "주문에 필요한 상품 정보를 찾을 수 없습니다.");
-        }
-
-        List<OrderCommand.Line> lines = criteria.lines().stream()
-                .map(line ->
-                        new OrderCommand.Line(line.productId(), line.quantity(), productInfos.get(line.productId()).price()))
-                .toList();
-
-        BigDecimal originalAmount = lines.stream()
-                .map(line -> line.unitPrice().multiply(BigDecimal.valueOf(line.quantity())))
-                .reduce(BigDecimal.ZERO, BigDecimal::add)
-                .setScale(0, RoundingMode.FLOOR);
-
-        BigDecimal paymentAmount = (criteria.couponId() != null) ?
-                couponService.use(new CouponCommand.Use(criteria.couponId(), criteria.userId(), originalAmount)).paymentAmount()
-                : originalAmount;
-
-        OrderInfo orderInfo = orderService.order(criteria.toOrderCommandWith(lines, originalAmount, paymentAmount));
-
-        pointService.use(new PointCommand.Use(criteria.userId(), orderInfo.payment().paymentAmount().longValue()));
-
-        stockService.deductAll(criteria.toCommandDeduct());
+        OrderInfo orderInfo = orderProcessor.placeOrder(criteria);
+        PointCommand.Use pointCommand = new PointCommand.Use(criteria.userId(), orderInfo.payment().paymentAmount().longValue());
+        paymentProcessor.pay(pointCommand, criteria.toCommandDeduct());
 
         return OrderResult.from(orderInfo);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderProcessor.java
@@ -1,0 +1,51 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.OrderCommand.Line;
+import com.loopers.domain.order.OrderInfo;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.product.ProductCommand;
+import com.loopers.domain.product.ProductInfo;
+import com.loopers.domain.product.ProductService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderProcessor {
+    private final ProductService productService;
+    private final OrderService orderService;
+    private final DiscountProcessor discountProcessor;
+
+    public OrderInfo placeOrder(OrderCriteria.Order criteria) {
+        Set<Long> productIds = criteria.lines().stream().map(OrderCriteria.Line::productId).collect(Collectors.toSet());
+
+        Map<Long, BigDecimal> productPriceMap = productService.getPurchasableProducts(new ProductCommand.Purchasable(productIds))
+                .stream()
+                .collect(Collectors.toMap(ProductInfo::id, ProductInfo::price));
+        if (productPriceMap.size() != productIds.size()) {
+            throw new CoreException(ErrorType.NOT_FOUND, "주문에 필요한 상품 정보를 찾을 수 없습니다.");
+        }
+
+        List<Line> lines = criteria.toCommandLines(productPriceMap);
+
+        BigDecimal originalAmount = calculateOriginalAmountOf(lines);
+        BigDecimal paymentAmount = discountProcessor.applyDiscount(criteria.couponId(), criteria.userId(), originalAmount);
+
+        return orderService.order(criteria.toOrderCommandWith(lines, originalAmount, paymentAmount));
+    }
+
+    private static BigDecimal calculateOriginalAmountOf(List<Line> lines) {
+        return lines.stream()
+                .map(Line::amount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(0, RoundingMode.FLOOR);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
@@ -56,10 +56,12 @@ public record OrderResult(
     }
 
     public record Payment(
+            BigDecimal originalAmount,
             BigDecimal paymentAmount
     ) {
         public static Payment from(OrderInfo.Payment payment) {
             return new Payment(
+                    payment.originalAmount(),
                     payment.paymentAmount()
             );
         }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/PaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/PaymentProcessor.java
@@ -1,0 +1,22 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.point.PointCommand;
+import com.loopers.domain.point.PointService;
+import com.loopers.domain.stock.StockCommand;
+import com.loopers.domain.stock.StockService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentProcessor {
+
+    private final StockService stockService;
+    private final PointService pointService;
+
+    public void pay(PointCommand.Use pointCommand, List<StockCommand.Deduct> stockCommands) {
+        pointService.use(pointCommand);
+        stockService.deductAll(stockCommands);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/count/ProductCountRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/count/ProductCountRepository.java
@@ -10,5 +10,7 @@ public interface ProductCountRepository {
 
     Optional<ProductCount> findBy(Long productId);
 
+    Optional<ProductCount> findByWithLock(Long productId);
+
     List<ProductCount> findByProductIds(Set<Long> productIds);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/count/ProductCountService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/count/ProductCountService.java
@@ -23,7 +23,7 @@ public class ProductCountService {
 
     @Transactional
     public ProductCountInfo incrementLike(ProductCountCommand.Increment command) {
-        ProductCount productCount = productCountRepository.findBy(command.productId())
+        ProductCount productCount = productCountRepository.findByWithLock(command.productId())
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다."));
         productCount.incrementLike();
         return ProductCountInfo.from(productCount);
@@ -31,7 +31,7 @@ public class ProductCountService {
 
     @Transactional
     public ProductCountInfo decrementLike(ProductCountCommand.Decrement command) {
-        ProductCount productCount = productCountRepository.findBy(command.productId())
+        ProductCount productCount = productCountRepository.findByWithLock(command.productId())
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다."));
         productCount.decrementLike();
         return ProductCountInfo.from(productCount);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -1,0 +1,82 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "coupon")
+public class Coupon extends BaseEntity {
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Embedded
+    private DiscountPolicy discountPolicy;
+
+    @Column(name = "minimum_order_amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal minimumOrderAmount;
+
+    @Column(name = "expire_hours", nullable = false)
+    private Integer expireHours;
+
+    @Column(name = "remaining_quantity", nullable = false)
+    private Long remainingQuantity;
+
+    @Column(name = "issued_quantity", nullable = false)
+    private Long issuedQuantity;
+
+    protected Coupon() {
+    }
+
+    private Coupon(String name, DiscountPolicy discountPolicy, BigDecimal minimumOrderAmount, Integer expireHours,
+                   Long remainingQuantity, Long issuedQuantity) {
+        this.name = name;
+        this.discountPolicy = discountPolicy;
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.expireHours = expireHours;
+        this.remainingQuantity = remainingQuantity;
+        this.issuedQuantity = issuedQuantity;
+    }
+
+    public static Coupon of(CouponCommand.Create command) {
+        if (command.name() == null || command.name().isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 이름은 필수입니다.");
+        }
+        if (command.discountPolicy() == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "할인 정책은 필수입니다.");
+        }
+        if (command.minimumOrderAmount() == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "최소 주문 금액은 필수입니다.");
+        }
+        if (command.minimumOrderAmount().compareTo(BigDecimal.ZERO) < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰을 적용하기 위한 최소 주문 금액은 0 이상이어야 합니다.");
+        }
+        if (command.expireHours() == null || command.expireHours() <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 유효 시간은 1시간 이상이어야 합니다.");
+        }
+        if (command.remainingQuantity() == null || command.remainingQuantity() < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 수량은 0 이상이어야 합니다.");
+        }
+
+        return new Coupon(command.name(), command.discountPolicy(), command.minimumOrderAmount(), command.expireHours(),
+                command.remainingQuantity(), 0L);
+    }
+
+    public UserCoupon issue(Long userId, LocalDateTime now) {
+        if (remainingQuantity <= 0) {
+            throw new CoreException(ErrorType.CONFLICT, "쿠폰이 모두 소진되었습니다.");
+        }
+        remainingQuantity--;
+        issuedQuantity++;
+        return UserCoupon.of(userId, this.getId(), discountPolicy, now.plusHours(expireHours));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponCommand.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+public class CouponCommand {
+    public record Create(
+            String name,
+            DiscountPolicy discountPolicy,
+            BigDecimal minimumOrderAmount,
+            Integer expireHours,
+            Long remainingQuantity
+    ) {
+    }
+
+    public record Issue(Long couponId, Long userId) {
+    }
+
+    public record Use(Long couponId, Long userId, BigDecimal originalAmount) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponInfo.java
@@ -1,0 +1,25 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+public record CouponInfo(
+        Long id,
+        String name,
+        DiscountPolicy discountPolicy,
+        BigDecimal minimumOrderAmount,
+        Integer expireHours,
+        Long remainingQuantity,
+        Long issuedQuantity
+) {
+    public static CouponInfo from(Coupon coupon) {
+        return new CouponInfo(
+                coupon.getId(),
+                coupon.getName(),
+                coupon.getDiscountPolicy(),
+                coupon.getMinimumOrderAmount(),
+                coupon.getExpireHours(),
+                coupon.getRemainingQuantity(),
+                coupon.getIssuedQuantity()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.coupon;
+
+import java.util.Optional;
+
+public interface CouponRepository {
+
+    Coupon save(Coupon coupon);
+
+    UserCoupon save(UserCoupon userCoupon);
+
+    Optional<Coupon> findById(Long couponId);
+
+    Optional<Coupon> findCouponWithLock(Long couponId);
+
+    Optional<UserCoupon> findUserCoupon(Long couponId, Long userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.transaction.Transactional;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+    private final DiscountPolicyAdapter discountPolicyAdapter;
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public CouponInfo issue(CouponCommand.Issue command) {
+        Coupon coupon = couponRepository.findCouponWithLock(command.couponId())
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "쿠폰을 찾을 수 없습니다."));
+        UserCoupon userCoupon = coupon.issue(command.userId(), LocalDateTime.now());
+        try {
+            couponRepository.save(userCoupon);
+        } catch (DataIntegrityViolationException e) {
+            throw new CoreException(ErrorType.CONFLICT, "이미 쿠폰을 소유하고 있습니다.");
+        }
+        return CouponInfo.from(coupon);
+    }
+
+    @Transactional
+    public UserCouponInfo.Use use(CouponCommand.Use command) {
+        UserCoupon userCoupon = couponRepository.findUserCoupon(command.couponId(), command.userId())
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "쿠폰을 소유하고 있지 않습니다."));
+        DiscountStrategy discountStrategy = discountPolicyAdapter.from(userCoupon.getDiscountPolicy());
+        BigDecimal paymentAmount = discountStrategy.discount(command.originalAmount());
+        userCoupon.use(LocalDateTime.now());
+        return new UserCouponInfo.Use(userCoupon.getId(), command.originalAmount(), paymentAmount);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicy.java
@@ -1,0 +1,49 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.math.BigDecimal;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+@Embeddable
+public class DiscountPolicy {
+
+    @Column(name = "value", nullable = false, precision = 10, scale = 2)
+    private BigDecimal value;
+
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    protected DiscountPolicy() {
+    }
+
+    public DiscountPolicy(BigDecimal value, Type type) {
+        if (value == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "할인 금액 또는 할인율은 필수입니다.");
+        }
+        if (type == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 유형은 필수입니다.");
+        }
+        if (type == Type.RATE && (value.compareTo(BigDecimal.ZERO) <= 0 || value.compareTo(BigDecimal.ONE) > 0)) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "할인율은 0보다 크고 1 이하이어야 합니다.");
+        }
+        if (type == Type.FIXED && value.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "고정 할인 금액 은 0보다 커야 합니다.");
+        }
+
+        this.value = value;
+        this.type = type;
+    }
+
+    public enum Type {
+        RATE,
+        FIXED
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicyAdapter.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicyAdapter.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.coupon;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DiscountPolicyAdapter {
+
+    public DiscountPolicyAdapter() {
+    }
+
+    public DiscountStrategy from(DiscountPolicy discountPolicy) {
+        return switch (discountPolicy.getType()) {
+            case FIXED -> new FixedDiscountStrategy(discountPolicy);
+            case RATE -> new RateDiscountStrategy(discountPolicy);
+        };
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountStrategy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountStrategy.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+public interface DiscountStrategy {
+    BigDecimal discount(BigDecimal amount);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedDiscountStrategy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedDiscountStrategy.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class FixedDiscountStrategy implements DiscountStrategy {
+
+    private final BigDecimal amount;
+
+    public FixedDiscountStrategy(DiscountPolicy discountPolicy) {
+        this.amount = discountPolicy.getValue();
+    }
+
+    @Override
+    public BigDecimal discount(BigDecimal amount) {
+        return amount.subtract(this.amount).setScale(0, RoundingMode.FLOOR).max(BigDecimal.ZERO);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/RateDiscountStrategy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/RateDiscountStrategy.java
@@ -1,0 +1,19 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class RateDiscountStrategy implements DiscountStrategy {
+
+    private final BigDecimal rate;
+
+    public RateDiscountStrategy(DiscountPolicy discountPolicy) {
+        this.rate = discountPolicy.getValue();
+    }
+
+    @Override
+    public BigDecimal discount(BigDecimal amount) {
+        BigDecimal discount = amount.multiply(rate);
+        return amount.subtract(discount).setScale(0, RoundingMode.FLOOR);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
@@ -1,0 +1,84 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(
+        name = "user_coupon",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"ref_user_id", "ref_coupon_id"}))
+public class UserCoupon extends BaseEntity {
+
+    @Column(name = "ref_user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "ref_coupon_id", nullable = false)
+    private Long couponId;
+
+    @Embedded
+    private DiscountPolicy discountPolicy;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+    @Column(name = "expired_at", nullable = false)
+    private LocalDateTime expiredAt;
+
+    @Version
+    private Long version;
+
+    protected UserCoupon() {
+    }
+
+    public UserCoupon(Long userId, Long couponId, DiscountPolicy discountPolicy, LocalDateTime expiredAt) {
+        this.userId = userId;
+        this.couponId = couponId;
+        this.discountPolicy = discountPolicy;
+        this.expiredAt = expiredAt;
+    }
+
+    public static UserCoupon of(Long userId, Long couponId, DiscountPolicy discountPolicy, LocalDateTime expiredAt) {
+        if (userId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "사용자 ID가 존재하지 않습니다.");
+        }
+        if (couponId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 ID가 존재하지 않습니다.");
+        }
+        if (discountPolicy == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "할인 정책이 존재하지 않습니다.");
+        }
+        if (expiredAt == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 만료 날짜가 존재하지 않습니다.");
+        }
+
+        return new UserCoupon(userId, couponId, discountPolicy, expiredAt);
+    }
+
+    public void use(LocalDateTime usedAt) {
+        if (isUsed()) {
+            throw new CoreException(ErrorType.CONFLICT, "이미 사용한 쿠폰입니다.");
+        }
+        if (isExpired(usedAt)) {
+            throw new CoreException(ErrorType.CONFLICT, "이미 만료된 쿠폰입니다.");
+        }
+        this.usedAt = usedAt;
+    }
+
+    public boolean isUsed() {
+        return this.usedAt != null;
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        return this.expiredAt.isBefore(now);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponInfo.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record UserCouponInfo(
+        Long id,
+        Long couponId,
+        Long userId,
+        DiscountPolicy discountPolicy,
+        LocalDateTime usedAt,
+        LocalDateTime expiredAt
+) {
+    public record Use(
+            Long id,
+            BigDecimal originalAmount,
+            BigDecimal paymentAmount
+    ) {
+    }
+
+    public static UserCouponInfo from(UserCoupon userCoupon) {
+        return new UserCouponInfo(
+                userCoupon.getId(),
+                userCoupon.getCouponId(),
+                userCoupon.getUserId(),
+                userCoupon.getDiscountPolicy(),
+                userCoupon.getUsedAt(),
+                userCoupon.getExpiredAt()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
@@ -15,7 +15,7 @@ public class OrderCommand {
     public record Line(
             Long productId,
             Long quantity,
-            BigDecimal unitPrice
+            BigDecimal amount
     ) {
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
@@ -7,7 +7,9 @@ public class OrderCommand {
     public record Order(
             Long userId,
             List<Line> lines,
-            Delivery delivery
+            Delivery delivery,
+            BigDecimal originalAmount,
+            BigDecimal paymentAmount
     ) {
     }
     public record Line(

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
@@ -57,10 +57,12 @@ public record OrderInfo(
     }
 
     public record Payment(
+            BigDecimal originalAmount,
             BigDecimal paymentAmount
     ) {
         public static Payment from(OrderPayment orderPayment) {
             return new Payment(
+                    orderPayment.getOriginalAmount(),
                     orderPayment.getPaymentAmount()
             );
         }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderLine.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderLine.java
@@ -38,7 +38,7 @@ public class OrderLine extends BaseEntity {
     public OrderLine(OrderCommand.Line line) {
         this.productId = line.productId();
         this.quantity = line.quantity();
-        this.amount = line.unitPrice().multiply(BigDecimal.valueOf(line.quantity()));
+        this.amount = line.amount();
     }
 
     public static OrderLine from(OrderCommand.Line line) {
@@ -54,7 +54,7 @@ public class OrderLine extends BaseEntity {
             throw new CoreException(ErrorType.BAD_REQUEST, "수량은 1 이상이어야 합니다.");
         }
 
-        if (line.unitPrice() == null || line.unitPrice().compareTo(BigDecimal.ZERO) < 0) {
+        if (line.amount() == null || line.amount().compareTo(BigDecimal.ZERO) < 0) {
             throw new CoreException(ErrorType.BAD_REQUEST, "가격은 0 이상이어야 합니다.");
         }
 
@@ -71,7 +71,7 @@ public class OrderLine extends BaseEntity {
                         (l1, l2) ->
                                 new OrderCommand.Line(l1.productId(),
                                         l1.quantity() + l2.quantity(),
-                                        l1.unitPrice()))
+                                        l1.amount().add(l2.amount())))
                 ).values().stream()
                 .toList();
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderPayment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderPayment.java
@@ -11,27 +11,29 @@ import lombok.Getter;
 @Getter
 public class OrderPayment {
 
+    private BigDecimal originalAmount;
+
+
     private BigDecimal paymentAmount;
 
     protected OrderPayment() {
     }
 
-    public OrderPayment(BigDecimal paymentAmount) {
+    public OrderPayment(BigDecimal originalAmount, BigDecimal paymentAmount) {
+        if (originalAmount == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "총 금액이 존재하지 않습니다.");
+        }
+        if (originalAmount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "총 금액은 0 이상이어야 합니다.");
+        }
         if (paymentAmount == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "결제 금액이 존재하지 않습니다.");
         }
         if (paymentAmount.compareTo(BigDecimal.ZERO) < 0) {
             throw new CoreException(ErrorType.BAD_REQUEST, "결제 금액은 0 이상이어야 합니다.");
         }
-
+        this.originalAmount = originalAmount;
         this.paymentAmount = paymentAmount;
-    }
-
-    public OrderPayment add(BigDecimal amount) {
-        if (amount == null || amount.compareTo(BigDecimal.ZERO) < 0) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "추가 금액은 0 이상이어야 합니다.");
-        }
-        return new OrderPayment(this.paymentAmount.add(amount));
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -15,9 +15,7 @@ public class OrderService {
 
     @Transactional
     public OrderInfo order(OrderCommand.Order command) {
-        Order order = Order.of(command.userId(), command.delivery());
-        List<OrderLine> orderLines = OrderLine.of(command.lines());
-        orderLines.forEach(order::addLine);
+        Order order = Order.of(command);
         return OrderInfo.from(orderRepository.save(order));
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -8,6 +8,8 @@ public interface PointRepository {
 
     Optional<Point> findByUserId(Long userId);
 
+    Optional<Point> findByUserIdWithLock(Long userId);
+
     boolean existsByUserId(Long userId);
 
     PointHistory record(PointHistory pointHistory);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -29,7 +29,7 @@ public class PointService {
 
     @Transactional
     public PointInfo charge(PointCommand.Charge command) {
-        Point point = pointRepository.findByUserId(command.userId())
+        Point point = pointRepository.findByUserIdWithLock(command.userId())
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 사용자입니다."));
         PointHistory chargeHistory = point.charge(command.amount());
         pointRepository.record(chargeHistory);
@@ -38,7 +38,7 @@ public class PointService {
 
     @Transactional
     public PointInfo use(PointCommand.Use command) {
-        Point point = pointRepository.findByUserId(command.userId())
+        Point point = pointRepository.findByUserIdWithLock(command.userId())
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 사용자입니다."));
         PointHistory useHistory = point.use(command.amount());
         pointRepository.record(useHistory);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCommand.java
@@ -15,7 +15,7 @@ public class ProductCommand {
     public record Find(Long productId) {
     }
 
-    public record GetProducts(Set<Long> productIds) {
+    public record Purchasable(Set<Long> productIds) {
     }
 
     public record Page(

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.product;
 
 import com.loopers.domain.PageResponse;
+import com.loopers.domain.product.ProductCommand.Purchasable;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import java.util.List;
@@ -23,7 +24,7 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProductInfo> getPurchasableProducts(ProductCommand.GetProducts command) {
+    public List<ProductInfo> getPurchasableProducts(Purchasable command) {
         if (command.productIds() == null || command.productIds().isEmpty()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "상품 ID 목록이 비어 있습니다.");
         }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
@@ -13,7 +13,7 @@ import jakarta.persistence.Table;
 @Table(name = "stock")
 public class Stock extends BaseEntity {
 
-    @Column(name = "ref_product_id", nullable = false)
+    @Column(name = "ref_product_id", nullable = false, unique = true)
     private Long productId;
 
     @Embedded

--- a/apps/commerce-api/src/main/java/com/loopers/domain/stock/StockRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/stock/StockRepository.java
@@ -7,4 +7,6 @@ public interface StockRepository {
     Stock save(Stock stock);
 
     Optional<Stock> findByProductId(Long productId);
+
+    Optional<Stock> findByProductIdWithLock(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/stock/StockService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/stock/StockService.java
@@ -2,12 +2,15 @@ package com.loopers.domain.stock;
 
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class StockService {
 
@@ -22,7 +25,7 @@ public class StockService {
 
     @Transactional
     public StockInfo deduct(StockCommand.Deduct command) {
-        Stock stock = stockRepository.findByProductId(command.productId())
+        Stock stock = stockRepository.findByProductIdWithLock(command.productId())
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다."));
         stock.deduct(command.quantity());
         return StockInfo.from(stock);
@@ -31,6 +34,7 @@ public class StockService {
     @Transactional
     public List<StockInfo> deductAll(List<StockCommand.Deduct> commands) {
         return commands.stream()
+                .sorted(Comparator.comparing(StockCommand.Deduct::productId))
                 .map(this::deduct)
                 .toList();
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/count/ProductCountJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/count/ProductCountJpaRepository.java
@@ -1,9 +1,16 @@
 package com.loopers.infrastructure.count;
 
 import com.loopers.domain.count.ProductCount;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProductCountJpaRepository extends JpaRepository<ProductCount, Long> {
     Optional<ProductCount> findByProductId(Long productId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT pc FROM ProductCount pc WHERE pc.productId = :productId")
+    Optional<ProductCount> findByProductIdWithLock(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/count/ProductCountRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/count/ProductCountRepositoryImpl.java
@@ -25,6 +25,11 @@ public class ProductCountRepositoryImpl implements ProductCountRepository {
     }
 
     @Override
+    public Optional<ProductCount> findByWithLock(Long productId) {
+        return productCountJpaRepository.findByProductIdWithLock(productId);
+    }
+
+    @Override
     public List<ProductCount> findByProductIds(Set<Long> productIds) {
         return productCountJpaRepository.findAllById(productIds);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.Coupon;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Coupon c WHERE c.id = :couponId")
+    Optional<Coupon> findByIdWithLock(Long couponId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.Coupon;
+import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.domain.coupon.UserCoupon;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponRepositoryImpl implements CouponRepository {
+
+    private final CouponJpaRepository couponJpaRepository;
+    private final UserCouponJpaRepository userCouponJpaRepository;
+
+    @Override
+    public Coupon save(Coupon coupon) {
+        return couponJpaRepository.save(coupon);
+    }
+
+    @Override
+    public UserCoupon save(UserCoupon userCoupon) {
+        return userCouponJpaRepository.save(userCoupon);
+    }
+
+    @Override
+    public Optional<Coupon> findById(Long couponId) {
+        return couponJpaRepository.findById(couponId);
+    }
+
+    @Override
+    public Optional<Coupon> findCouponWithLock(Long couponId) {
+        return couponJpaRepository.findByIdWithLock(couponId);
+    }
+
+    @Override
+    public Optional<UserCoupon> findUserCoupon(Long couponId, Long userId) {
+        return userCouponJpaRepository.findByCouponIdAndUserId(couponId, userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.UserCoupon;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserCouponJpaRepository extends JpaRepository<UserCoupon, Long> {
+
+    Optional<UserCoupon> findByCouponIdAndUserId(Long couponId, Long userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,11 +1,18 @@
 package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.Point;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PointJpaRepository extends JpaRepository<Point, Long> {
     Optional<Point> findByUserId(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Point p WHERE p.userId = :userId")
+    Optional<Point> findByUserIdWithLock(Long userId);
 
     boolean existsByUserId(Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -25,6 +25,11 @@ public class PointRepositoryImpl implements PointRepository {
     }
 
     @Override
+    public Optional<Point> findByUserIdWithLock(Long userId) {
+        return pointJpaRepository.findByUserIdWithLock(userId);
+    }
+
+    @Override
     public boolean existsByUserId(Long userId) {
         return pointJpaRepository.existsByUserId(userId);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockJpaRepository.java
@@ -1,10 +1,17 @@
 package com.loopers.infrastructure.stock;
 
 import com.loopers.domain.stock.Stock;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StockJpaRepository extends JpaRepository<Stock, Long> {
 
     Optional<Stock> findByProductId(Long productId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM Stock s WHERE s.productId = :productId")
+    Optional<Stock> findByProductIdWithLock(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockRepositoryImpl.java
@@ -21,4 +21,9 @@ public class StockRepositoryImpl implements StockRepository {
     public Optional<Stock> findByProductId(Long productId) {
         return stockJpaRepository.findByProductId(productId);
     }
+
+    @Override
+    public Optional<Stock> findByProductIdWithLock(Long productId) {
+        return stockJpaRepository.findByProductIdWithLock(productId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiController.java
@@ -29,7 +29,7 @@ public class OrderV1ApiController implements OrderV1ApiSpec {
                 .map(OrderV1Dto.Line::toCriteriaLine)
                 .toList();
         OrderResult orderResult = orderFacade.order(
-                new OrderCriteria.Order(userId, lines, orderRequest.delivery().toCriteriaDelivery()));
+                new OrderCriteria.Order(userId, lines, orderRequest.delivery().toCriteriaDelivery(), orderRequest.couponId()));
         return ApiResponse.success(OrderV1Dto.OrderResponse.from(orderResult));
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -8,8 +8,8 @@ import java.util.List;
 public class OrderV1Dto {
     public record OrderRequest(
             List<Line> lines,
-            Delivery delivery
-
+            Delivery delivery,
+            Long couponId
     ) {
     }
 
@@ -45,7 +45,7 @@ public class OrderV1Dto {
             List<Line> lines,
             Delivery delivery,
             Payment payment
-            ) {
+    ) {
         public static OrderResponse from(OrderResult orderResult) {
             List<Line> lines = orderResult.lines().stream()
                     .map(line -> new Line(line.productId(), line.quantity()))
@@ -57,12 +57,13 @@ public class OrderV1Dto {
                     orderResult.delivery().detailAddress(),
                     orderResult.delivery().requirements()
             );
-            Payment payment = new Payment(orderResult.payment().paymentAmount());
+            Payment payment = new Payment(orderResult.payment().originalAmount(), orderResult.payment().paymentAmount());
             return new OrderResponse(orderResult.id(), lines, delivery, payment);
         }
     }
 
     public record Payment(
+            BigDecimal originalAmount,
             BigDecimal paymentAmount
     ) {
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/DiscountProcessorTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/DiscountProcessorTest.java
@@ -1,0 +1,32 @@
+package com.loopers.application.order;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.loopers.domain.coupon.CouponService;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DiscountProcessorTest {
+    @InjectMocks
+    private DiscountProcessor discountProcessor;
+    @Mock
+    private CouponService couponService;
+
+    @DisplayName("쿠폰 id가 null인 경우, 할인 금액이 적용되지 않아야 한다.")
+    @Test
+    void doesNotApplyDiscount_whenCouponIdIsNull() {
+        Long couponId = null;
+        Long userId = 1L;
+        BigDecimal originalAmount = BigDecimal.valueOf(1000);
+
+        BigDecimal paymentAmount = discountProcessor.applyDiscount(couponId, userId, originalAmount);
+
+        assertEquals(originalAmount, paymentAmount);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
@@ -1,11 +1,14 @@
 package com.loopers.application.order;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.domain.coupon.DiscountPolicy;
+import com.loopers.domain.coupon.DiscountPolicy.Type;
+import com.loopers.domain.coupon.UserCoupon;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderCommand;
 import com.loopers.domain.order.OrderLine;
@@ -25,6 +28,7 @@ import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
@@ -34,8 +38,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -50,6 +52,8 @@ class OrderFacadeIntegrationTest {
     private PointRepository pointRepository;
     @Autowired
     private ProductRepository productRepository;
+    @Autowired
+    private CouponRepository couponRepository;
     @Autowired
     private StockRepository stockRepository;
     @Autowired
@@ -77,24 +81,23 @@ class OrderFacadeIntegrationTest {
                     "요구사항"
             );
             CoreException thrown = assertThrows(CoreException.class,
-                    () -> orderFacade.order(new OrderCriteria.Order(-1L, List.of(new OrderCriteria.Line(1L, 3L), new OrderCriteria.Line(1L, 2L)), delivery)));
+                    () -> orderFacade.order(new OrderCriteria.Order(-1L, List.of(new OrderCriteria.Line(1L, 3L), new OrderCriteria.Line(1L, 2L)), delivery, null)));
 
             assertThat(thrown)
                     .usingRecursiveComparison()
                     .isEqualTo(new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다."));
         }
 
-        @DisplayName("주문 수량이 0 이하인 경우, BAD_REQUEST 예외를 발생시킨다.")
-        @ValueSource(longs = {0, -1})
-        @ParameterizedTest
-        void throwBadRequestException_whenOrderQuantityIsNegative(Long quantity) {
+        @DisplayName("주문 수량이 음수인 경우, BAD_REQUEST 예외를 발생시킨다.")
+        @Test
+        void throwBadRequestException_whenOrderQuantityIsNegative() {
             User user = userRepository.save(User.create(new UserCommand.Join("test1", "hgh1472@loopers.im", "1999-06-23", "MALE")));
             Point point = Point.from(user.getId());
             point.charge(10000L);
             pointRepository.save(point);
             Product product = productRepository.save(Product.create(new ProductCommand.Create(1L, "Test Product1", new BigDecimal("1000.00"), "ON_SALE")));
             stockRepository.save(Stock.create(new StockCommand.Create(product.getId(), 100L)));
-            List<OrderCriteria.Line> lines = List.of(new OrderCriteria.Line(product.getId(), quantity));
+            List<OrderCriteria.Line> lines = List.of(new OrderCriteria.Line(product.getId(), -1L));
             OrderCriteria.Delivery delivery = new OrderCriteria.Delivery(
                     "황건하",
                     "010-1234-5678",
@@ -103,7 +106,32 @@ class OrderFacadeIntegrationTest {
                     "요구사항"
             );
 
-            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(user.getId(), lines, delivery)));
+            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(user.getId(), lines, delivery, null)));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "총 금액은 0 이상이어야 합니다."));
+        }
+
+        @DisplayName("주문 수량이 0인 경우, BAD_REQUEST 예외를 발생시킨다.")
+        @Test
+        void throwBadRequestException_whenOrderQuantityIsZero() {
+            User user = userRepository.save(User.create(new UserCommand.Join("test1", "hgh1472@loopers.im", "1999-06-23", "MALE")));
+            Point point = Point.from(user.getId());
+            point.charge(10000L);
+            pointRepository.save(point);
+            Product product = productRepository.save(Product.create(new ProductCommand.Create(1L, "Test Product1", new BigDecimal("1000.00"), "ON_SALE")));
+            stockRepository.save(Stock.create(new StockCommand.Create(product.getId(), 100L)));
+            List<OrderCriteria.Line> lines = List.of(new OrderCriteria.Line(product.getId(), 0L));
+            OrderCriteria.Delivery delivery = new OrderCriteria.Delivery(
+                    "황건하",
+                    "010-1234-5678",
+                    "서울특별시 강남구 테헤란로 123",
+                    "1층 101호",
+                    "요구사항"
+            );
+
+            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(user.getId(), lines, delivery, null)));
 
             assertThat(thrown)
                     .usingRecursiveComparison()
@@ -127,7 +155,7 @@ class OrderFacadeIntegrationTest {
                     "요구사항"
             );
 
-            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(user.getId(), lines, delivery)));
+            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(user.getId(), lines, delivery, null)));
 
             assertThat(thrown)
                     .usingRecursiveComparison()
@@ -152,7 +180,7 @@ class OrderFacadeIntegrationTest {
                     "요구사항"
             );
 
-            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(user.getId(), lines, delivery)));
+            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(user.getId(), lines, delivery, null)));
 
             assertThat(thrown)
                     .usingRecursiveComparison()
@@ -166,7 +194,7 @@ class OrderFacadeIntegrationTest {
             Point point = Point.from(user.getId());
             point.charge(30000L);
             pointRepository.save(point);
-            Product product = productRepository.save(Product.create(new ProductCommand.Create(1L, "Test Product1", new BigDecimal("5000.00"), "ON_SALE")));
+            Product product = productRepository.save(Product.create(new ProductCommand.Create(1L, "Test Product1", new BigDecimal("5000"), "ON_SALE")));
             stockRepository.save(Stock.create(new StockCommand.Create(product.getId(), 100L)));
             OrderCriteria.Delivery delivery = new OrderCriteria.Delivery(
                     "황건하",
@@ -175,7 +203,8 @@ class OrderFacadeIntegrationTest {
                     "1층 101호",
                     "요구사항"
             );
-            OrderResult orderResult = orderFacade.order(new OrderCriteria.Order(user.getId(), List.of(new OrderCriteria.Line(product.getId(), 3L), new OrderCriteria.Line(product.getId(), 2L)), delivery));
+            List<OrderCriteria.Line> lines = List.of(new OrderCriteria.Line(product.getId(), 3L), new OrderCriteria.Line(product.getId(), 2L));
+            OrderResult orderResult = orderFacade.order(new OrderCriteria.Order(user.getId(), lines, delivery, null));
 
             assertAll(
                     () -> assertThat(orderResult.lines().size()).isEqualTo(1),
@@ -203,8 +232,8 @@ class OrderFacadeIntegrationTest {
                     "1층 101호",
                     "요구사항"
             );
-
-            OrderResult orderResult = orderFacade.order(new OrderCriteria.Order(user.getId(), List.of(new OrderCriteria.Line(product1.getId(), 3L), new OrderCriteria.Line(product2.getId(), 2L)), delivery));
+            List<OrderCriteria.Line> lines = List.of(new OrderCriteria.Line(product1.getId(), 3L), new OrderCriteria.Line(product2.getId(), 2L));
+            OrderResult orderResult = orderFacade.order(new OrderCriteria.Order(user.getId(), lines, delivery, null));
 
             Optional<Order> order = orderRepository.findById(orderResult.id());
             Point afterPoint = pointRepository.findByUserId(user.getId()).get();
@@ -215,6 +244,41 @@ class OrderFacadeIntegrationTest {
                             .contains(tuple(product1.getId(), 3L, product1.getPrice().getValue().multiply(BigDecimal.valueOf(3))),
                                     tuple(product2.getId(), 2L, product2.getPrice().getValue().multiply(BigDecimal.valueOf(2)))),
                     () -> assertThat(order.get().getOrderPayment().getPaymentAmount()).isEqualTo(new BigDecimal("7000.00"))
+            );
+        }
+
+        @DisplayName("쿠폰을 사용하여 주문하는 경우, 쿠폰이 적용되어야 한다.")
+        @Test
+        void order_withCoupon() {
+            User user = userRepository.save(User.create(new UserCommand.Join("test1", "hgh1472@loopers.im", "1999-06-23", "MALE")));
+            Point point = Point.from(user.getId());
+            point.charge(10000L);
+            pointRepository.save(point);
+            Long couponId = 1L;
+            couponRepository.save(UserCoupon.of(user.getId(), couponId, new DiscountPolicy(BigDecimal.valueOf(1000), Type.FIXED), LocalDateTime.now().plusDays(10)));
+            Product product1 = productRepository.save(Product.create(new ProductCommand.Create(1L, "Test Product1", new BigDecimal("1000.00"), "ON_SALE")));
+            stockRepository.save(Stock.create(new StockCommand.Create(product1.getId(), 100L)));
+            Product product2 = productRepository.save(Product.create(new ProductCommand.Create(1L, "Test Product2", new BigDecimal("2000.00"), "ON_SALE")));
+            stockRepository.save(Stock.create(new StockCommand.Create(product2.getId(), 100L)));
+            OrderCriteria.Delivery delivery = new OrderCriteria.Delivery(
+                    "황건하",
+                    "010-1234-5678",
+                    "서울특별시 강남구 테헤란로 123",
+                    "1층 101호",
+                    "요구사항"
+            );
+            List<OrderCriteria.Line> lines = List.of(new OrderCriteria.Line(product1.getId(), 3L), new OrderCriteria.Line(product2.getId(), 2L));
+            OrderResult orderResult = orderFacade.order(new OrderCriteria.Order(user.getId(), lines, delivery, couponId));
+
+            Order order = orderRepository.findById(orderResult.id()).orElseThrow();
+            Point afterPoint = pointRepository.findByUserId(user.getId()).get();
+            assertAll(
+                    () -> assertThat(afterPoint.getAmount().getValue()).isEqualTo(4000L),
+                    () -> assertThat(order.getOrderLines()).extracting("productId", "quantity", "amount")
+                            .contains(tuple(product1.getId(), 3L, product1.getPrice().getValue().multiply(BigDecimal.valueOf(3))),
+                                    tuple(product2.getId(), 2L, product2.getPrice().getValue().multiply(BigDecimal.valueOf(2)))),
+                    () -> assertThat(orderResult.payment().originalAmount()).isEqualTo(new BigDecimal("7000")),
+                    () -> assertThat(orderResult.payment().paymentAmount()).isEqualTo(new BigDecimal("6000"))
             );
         }
     }
@@ -248,7 +312,7 @@ class OrderFacadeIntegrationTest {
                 executorService.submit(() -> {
                     try {
                         orderFacade.order(new OrderCriteria.Order(user.getId(),
-                                List.of(new OrderCriteria.Line(product1.getId(), 10L), new OrderCriteria.Line(product2.getId(), 10L)), delivery));
+                                List.of(new OrderCriteria.Line(product1.getId(), 10L), new OrderCriteria.Line(product2.getId(), 10L)), delivery, null));
                     } catch (Exception e) {
                         System.out.println("Order failed: " + e.getMessage());
                     } finally {
@@ -292,7 +356,10 @@ class OrderFacadeIntegrationTest {
                     "서울특별시 강남구 테헤란로 123",
                     "1층 101호",
                     "요구사항");
-            Order order = Order.of(user1.getId(), delivery);
+            List<OrderCommand.Line> orderLines = List.of(new OrderCommand.Line(1L, 2L, new BigDecimal("1000.00")));
+            OrderCommand.Order cmd = new OrderCommand.Order(user1.getId(), orderLines, delivery, BigDecimal.valueOf(2000), BigDecimal.valueOf(2000));
+            Order order = Order.of(cmd);
+
             order.addLine(OrderLine.from(new OrderCommand.Line(1L, 2L, new BigDecimal("1000.00"))));
             Order saved = orderRepository.save(order);
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
@@ -4,21 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
-import com.loopers.domain.order.OrderService;
-import com.loopers.domain.point.PointService;
-import com.loopers.domain.product.ProductCommand;
-import com.loopers.domain.product.ProductInfo;
-import com.loopers.domain.product.ProductService;
-import com.loopers.domain.stock.StockService;
 import com.loopers.domain.user.UserCommand;
-import com.loopers.domain.user.UserInfo;
 import com.loopers.domain.user.UserService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,13 +25,9 @@ class OrderFacadeTest {
     @Mock
     private UserService userService;
     @Mock
-    private ProductService productService;
+    private OrderProcessor orderProcessor;
     @Mock
-    private OrderService orderService;
-    @Mock
-    private StockService stockService;
-    @Mock
-    private PointService pointService;
+    private PaymentProcessor paymentProcessor;
 
     @Nested
     @DisplayName("주문 시,")
@@ -61,26 +47,5 @@ class OrderFacadeTest {
                     .usingRecursiveComparison()
                     .isEqualTo(new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다."));
         }
-
-        @DisplayName("주문에 필요한 상품 정보가 없는 경우, NOT_FOUND 예외를 발생시킨다.")
-        @Test
-        void throwNotFoundException_whenProductInfoNotFound() {
-            UserInfo userInfo = new UserInfo(1L, "testUser", "hgh1472@naver.com", LocalDate.now(), "MALE");
-            given(userService.findUser(new UserCommand.Find(1L)))
-                    .willReturn(userInfo);
-            Set<Long> productIds = Set.of(1L, 2L);
-            given(productService.getPurchasableProducts(new ProductCommand.GetProducts(productIds)))
-                    .willReturn(List.of(new ProductInfo(1L, 2L, "상품 1", new BigDecimal("1000.00"), "ON_SALE")));
-
-            List<OrderCriteria.Line> lines = List.of(new OrderCriteria.Line(1L, 1L), new OrderCriteria.Line(2L, 1L));
-            OrderCriteria.Delivery delivery = new OrderCriteria.Delivery("주문자", "010-1234-5678", "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", "요청사항");
-
-            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(1L, lines, delivery, null)));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new CoreException(ErrorType.NOT_FOUND, "주문에 필요한 상품 정보를 찾을 수 없습니다."));
-        }
     }
-
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
@@ -55,7 +55,7 @@ class OrderFacadeTest {
             List<OrderCriteria.Line> lines = List.of(new OrderCriteria.Line(1L, 1L));
             OrderCriteria.Delivery delivery = new OrderCriteria.Delivery("주문자", "010-1234-5678", "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", "요청사항");
 
-            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(1L, lines, delivery)));
+            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(1L, lines, delivery, null)));
 
             assertThat(thrown)
                     .usingRecursiveComparison()
@@ -75,7 +75,7 @@ class OrderFacadeTest {
             List<OrderCriteria.Line> lines = List.of(new OrderCriteria.Line(1L, 1L), new OrderCriteria.Line(2L, 1L));
             OrderCriteria.Delivery delivery = new OrderCriteria.Delivery("주문자", "010-1234-5678", "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", "요청사항");
 
-            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(1L, lines, delivery)));
+            CoreException thrown = assertThrows(CoreException.class, () -> orderFacade.order(new OrderCriteria.Order(1L, lines, delivery, null)));
 
             assertThat(thrown)
                     .usingRecursiveComparison()

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderProcessorTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderProcessorTest.java
@@ -1,0 +1,57 @@
+package com.loopers.application.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.product.ProductCommand;
+import com.loopers.domain.product.ProductInfo;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.user.UserCommand;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderProcessorTest {
+    @InjectMocks
+    private OrderProcessor orderProcessor;
+    @Mock
+    private ProductService productService;
+    @Mock
+    private OrderService orderService;
+    @Mock
+    private DiscountProcessor discountProcessor;
+
+    @DisplayName("주문 상품 중, 구매 불가능한 상품이 있는 경우, NOT_FOUND 예외가 발생한다.")
+    @Test
+    void throwNotFoundException_whenNotPurchasable() {
+        List<OrderCriteria.Line> lines = List.of(
+            new OrderCriteria.Line(1L, 1L),
+            new OrderCriteria.Line(2L, 2L)
+        );
+        OrderCriteria.Delivery delivery = new OrderCriteria.Delivery("주문자", "010-1234-5678",
+                "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", "요청사항");
+        given(productService.getPurchasableProducts(new ProductCommand.Purchasable(Set.of(1L, 2L))))
+                .willReturn(List.of(new ProductInfo(1L, 2L, "상품1", BigDecimal.valueOf(1000), "ON_SALE")));
+
+        OrderCriteria.Order criteria = new OrderCriteria.Order(1L, lines, delivery, 1L);
+
+        CoreException thrown = assertThrows(CoreException.class, () -> orderProcessor.placeOrder(criteria));
+
+        assertThat(thrown)
+                .usingRecursiveComparison()
+                .isEqualTo(new CoreException(ErrorType.NOT_FOUND, "주문에 필요한 상품 정보를 찾을 수 없습니다."));
+    }
+
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/count/ProductCountServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/count/ProductCountServiceIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.loopers.domain.count;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.loopers.utils.DatabaseCleanUp;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ProductCountServiceIntegrationTest {
+
+    @Autowired
+    private ProductCountService productCountService;
+    @Autowired
+    private ProductCountRepository productCountRepository;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("상품 카운트 동시성 테스트")
+    class Concurrency {
+        @DisplayName("좋아요 수 증가가 동시에 요청되는 경우, 정확히 계산되어야 한다.")
+        @Test
+        void incrementLike_concurrency() throws InterruptedException {
+            productCountRepository.save(ProductCount.from(1L));
+            ProductCountCommand.Increment command = new ProductCountCommand.Increment(1L);
+            int threadCount = 10;
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            for (int i = 0; i < threadCount; i++) {
+                executor.submit(() -> {
+                    try {
+                        productCountService.incrementLike(command);
+                    } catch (Exception e) {
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            ProductCount productCount = productCountRepository.findBy(1L).orElseThrow();
+            assertThat(productCount.getLikeCount()).isEqualTo(threadCount);
+        }
+
+        @DisplayName("좋아요 수 감소가 동시에 요청되는 경우, 정확히 계산되어야 한다.")
+        @Test
+        void decrementLike_concurrency() throws InterruptedException {
+            ProductCount productCount = ProductCount.from(1L);
+            int threadCount = 10;
+            for (int i = 0; i < threadCount; i++) {
+                productCount.incrementLike();
+            }
+            productCountRepository.save(productCount);
+            ProductCountCommand.Decrement command = new ProductCountCommand.Decrement(1L);
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            for (int i = 0; i < threadCount; i++) {
+                executor.submit(() -> {
+                    try {
+                        productCountService.decrementLike(command);
+                    } catch (Exception e) {
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            ProductCount find = productCountRepository.findBy(1L).orElseThrow();
+            assertThat(find.getLikeCount()).isEqualTo(0);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/count/ProductCountServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/count/ProductCountServiceTest.java
@@ -45,7 +45,7 @@ public class ProductCountServiceTest {
         @Test
         void throwNotFoundException_whenProductDoesNotExist() {
             Long productId = 1L;
-            given(productCountRepository.findBy(productId))
+            given(productCountRepository.findByWithLock(productId))
                     .willReturn(Optional.empty());
 
             CoreException thrown = assertThrows(CoreException.class, () -> productCountService.incrementLike(new ProductCountCommand.Increment(productId)));
@@ -61,7 +61,7 @@ public class ProductCountServiceTest {
             Long productId = 1L;
             ProductCount productCount = ProductCount.from(productId);
             Long before = productCount.getLikeCount();
-            given(productCountRepository.findBy(productId))
+            given(productCountRepository.findByWithLock(productId))
                     .willReturn(Optional.of(productCount));
 
             ProductCountInfo result = productCountService.incrementLike(new ProductCountCommand.Increment(productId));
@@ -78,7 +78,7 @@ public class ProductCountServiceTest {
         @Test
         void throwNotFoundException_whenProductDoesNotExist() {
             Long productId = 1L;
-            given(productCountRepository.findBy(productId))
+            given(productCountRepository.findByWithLock(productId))
                     .willReturn(Optional.empty());
 
             CoreException thrown = assertThrows(CoreException.class, () -> productCountService.decrementLike(new ProductCountCommand.Decrement(productId)));
@@ -95,7 +95,7 @@ public class ProductCountServiceTest {
             ProductCount productCount = ProductCount.from(productId);
             productCount.incrementLike();
             Long before = productCount.getLikeCount();
-            given(productCountRepository.findBy(productId))
+            given(productCountRepository.findByWithLock(productId))
                     .willReturn(Optional.of(productCount));
 
             ProductCountInfo result = productCountService.decrementLike(new ProductCountCommand.Decrement(productId));

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
@@ -1,0 +1,173 @@
+package com.loopers.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.loopers.domain.coupon.DiscountPolicy.Type;
+import com.loopers.utils.DatabaseCleanUp;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CouponServiceIntegrationTest {
+    @Autowired
+    private CouponService couponService;
+    @Autowired
+    private CouponRepository couponRepository;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("쿠폰 사용 시,")
+    class Use {
+        @DisplayName("쿠폰을 중복해서 사용할 경우, 하나의 요청만 성공한다.")
+        @Test
+        void useCoupon_concurrency() throws InterruptedException {
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000.00"), Type.FIXED);
+            UserCoupon userCoupon = couponRepository.save(UserCoupon.of(1L, 1L, discountPolicy, LocalDateTime.now().plusHours(24)));
+            CouponCommand.Use cmd = new CouponCommand.Use(1L, 1L, new BigDecimal("5000.00"));
+            int threadCount = 10;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            int failCount = 0;
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        couponService.use(cmd);
+                    } catch (Exception e) {
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            UserCoupon afterUse = couponRepository.findUserCoupon(1L, 1L).orElseThrow();
+            assertThat(afterUse.getVersion()).isEqualTo(1);
+        }
+
+        @DisplayName("사용한 쿠폰 정보를 반환한다.")
+        @Test
+        void returnUserCouponInfo() {
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000.00"), Type.FIXED);
+            UserCoupon userCoupon = couponRepository.save(UserCoupon.of(1L, 1L, discountPolicy, LocalDateTime.now().plusHours(24)));
+            CouponCommand.Use cmd = new CouponCommand.Use(1L, 1L, new BigDecimal("5000.00"));
+
+            UserCouponInfo.Use use = couponService.use(cmd);
+
+            assertThat(use.id()).isEqualTo(userCoupon.getId());
+            assertThat(use.originalAmount()).isEqualTo(cmd.originalAmount());
+            assertThat(use.paymentAmount()).isEqualTo(new BigDecimal("4000"));
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 발급 시,")
+    class Issue {
+        @DisplayName("동시에 발급 요청을 하는 경우, 쿠폰 수량은 정확히 계산된다.")
+        @Test
+        void calculateQuantity_Concurrency() throws InterruptedException {
+            String name = "루퍼스 쿠폰";
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+            BigDecimal minimumOrderAmount = BigDecimal.ZERO;
+            Integer expireHours = 24;
+            Long initialRemainingQuantity = 10L;
+            CouponCommand.Create cmd = new CouponCommand.Create(name, discountPolicy, minimumOrderAmount, expireHours, initialRemainingQuantity);
+            Coupon coupon = couponRepository.save(Coupon.of(cmd));
+
+            int threadCount = 10;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            for (int i = 0; i < threadCount; i++) {
+                Long userId = (long) i;
+                executorService.submit(() -> {
+                    try {
+                        couponService.issue(new CouponCommand.Issue(coupon.getId(), userId));
+                    } catch (Exception e) {
+                        System.out.println("Error issuing coupon for " + e.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            Coupon after = couponRepository.findById(coupon.getId()).orElseThrow();
+            assertThat(after.getRemainingQuantity()).isEqualTo(0);
+            assertThat(after.getIssuedQuantity()).isEqualTo(threadCount);
+        }
+
+        @DisplayName("한 유저가 동시에 발급을 요청하는 경우, 하나의 요청만 성공한다.")
+        @Test
+        void issueCoupon_concurrency() throws InterruptedException {
+            String name = "루퍼스 쿠폰";
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+            BigDecimal minimumOrderAmount = BigDecimal.ZERO;
+            Integer expireHours = 24;
+            Long initialRemainingQuantity = 10L;
+            CouponCommand.Create cmd = new CouponCommand.Create(name, discountPolicy, minimumOrderAmount, expireHours, initialRemainingQuantity);
+            Coupon coupon = couponRepository.save(Coupon.of(cmd));
+
+            int threadCount = 10;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            Long userId = 1L;
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        couponService.issue(new CouponCommand.Issue(coupon.getId(), userId));
+                    } catch (Exception e) {
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            Coupon after = couponRepository.findById(coupon.getId()).orElseThrow();
+            assertThat(after.getIssuedQuantity()).isEqualTo(1);
+            assertThat(after.getRemainingQuantity()).isEqualTo(9);
+            UserCoupon userCoupon = couponRepository.findUserCoupon(coupon.getId(), userId).orElseThrow();
+            assertThat(userCoupon.getCouponId()).isEqualTo(coupon.getId());
+        }
+
+        @DisplayName("발급된 쿠폰 정보를 반환한다.")
+        @Test
+        void returnCouponInfo() {
+            String name = "루퍼스 쿠폰";
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000.00"), DiscountPolicy.Type.FIXED);
+            BigDecimal minimumOrderAmount = new BigDecimal("100.00");
+            Integer expireHours = 24;
+            Long initialRemainingQuantity = 10L;
+            CouponCommand.Create cmd = new CouponCommand.Create(name, discountPolicy, minimumOrderAmount, expireHours, initialRemainingQuantity);
+            Coupon coupon = couponRepository.save(Coupon.of(cmd));
+            Long userId = 1L;
+
+            CouponInfo couponInfo = couponService.issue(new CouponCommand.Issue(coupon.getId(), userId));
+
+            assertThat(couponInfo.id()).isEqualTo(coupon.getId());
+            assertThat(couponInfo.name()).isEqualTo(coupon.getName());
+            assertThat(couponInfo.discountPolicy()).isEqualTo(coupon.getDiscountPolicy());
+            assertThat(couponInfo.minimumOrderAmount()).isEqualTo(coupon.getMinimumOrderAmount());
+            assertThat(couponInfo.expireHours()).isEqualTo(coupon.getExpireHours());
+            assertThat(couponInfo.remainingQuantity()).isEqualTo(9);
+            assertThat(couponInfo.issuedQuantity()).isEqualTo(1);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceTest.java
@@ -1,0 +1,86 @@
+package com.loopers.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class CouponServiceTest {
+
+    @InjectMocks
+    private CouponService couponService;
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Nested
+    @DisplayName("쿠폰 사용 시,")
+    class Use {
+
+        @DisplayName("쿠폰을 소유하고 있지 않은 경우, NOT_FOUND 예외가 발생한다.")
+        @Test
+        void throwNotFoundException_whenCouponNotOwned() {
+            CouponCommand.Use command = new CouponCommand.Use(1L, 1L, new BigDecimal("10000"));
+            given(couponRepository.findUserCoupon(command.couponId(), command.userId()))
+                    .willReturn(Optional.empty());
+
+            CoreException exception = assertThrows(CoreException.class, () -> couponService.use(command));
+            assertThat(exception)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.NOT_FOUND, "쿠폰을 소유하고 있지 않습니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 발급 시,")
+    class Issue {
+
+        @DisplayName("쿠폰을 찾을 수 없는 경우, NOT_FOUND 예외가 발생한다.")
+        @Test
+        void throwNotFoundException_whenCouponNotFound() {
+            CouponCommand.Issue command = new CouponCommand.Issue(1L, 1L);
+            given(couponRepository.findCouponWithLock(command.couponId()))
+                    .willReturn(Optional.empty());
+
+            CoreException exception = assertThrows(CoreException.class, () -> couponService.issue(command));
+            assertThat(exception)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.NOT_FOUND, "쿠폰을 찾을 수 없습니다."));
+        }
+
+        @DisplayName("쿠폰을 이미 발급받은 경우, CONFLICT 예외가 발생한다.")
+        @Test
+        void throwConflictException_whenCouponAlreadyOwned() {
+            String name = "루퍼스 쿠폰";
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+            BigDecimal minimumOrderAmount = BigDecimal.ZERO;
+            Integer expireHours = 24;
+            Long initialRemainingQuantity = 10L;
+            Coupon coupon = Coupon.of(new CouponCommand.Create(name, discountPolicy, minimumOrderAmount, expireHours, initialRemainingQuantity));
+            CouponCommand.Issue command = new CouponCommand.Issue(1L, 1L);
+            given(couponRepository.findCouponWithLock(1L))
+                    .willReturn(Optional.of(coupon));
+            given(couponRepository.save(any(UserCoupon.class)))
+                    .willThrow(new DataIntegrityViolationException("이미 쿠폰 소유"));
+
+            CoreException exception = assertThrows(CoreException.class, () -> couponService.issue(command));
+
+            assertThat(exception)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.CONFLICT, "이미 쿠폰을 소유하고 있습니다."));
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
@@ -1,0 +1,182 @@
+package com.loopers.domain.coupon;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CouponTest {
+
+    @Nested
+    @DisplayName("쿠폰을 생성할 시,")
+    class Create {
+        @DisplayName("쿠폰 이름이 존재하지 않으면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenNameIsNullOrBlank() {
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+            BigDecimal minimumOrderAmount = BigDecimal.ZERO;
+            Integer expireHours = 24;
+            Long remainingQuantity = 100L;
+            CouponCommand.Create cmd = new CouponCommand.Create(null, discountPolicy, minimumOrderAmount, expireHours, remainingQuantity);
+
+            CoreException thrown = assertThrows(CoreException.class, () -> Coupon.of(cmd));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "쿠폰 이름은 필수입니다."));
+        }
+
+        @DisplayName("할인 정책이 존재하지 않으면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenTypeIsNull() {
+            String name = "루퍼스 쿠폰";
+            BigDecimal discountValue = new BigDecimal("10.00");
+            BigDecimal minimumOrderAmount = BigDecimal.ZERO;
+            Integer expireHours = 24;
+            Long remainingQuantity = 100L;
+            CouponCommand.Create cmd = new CouponCommand.Create(name, null, minimumOrderAmount, expireHours, remainingQuantity);
+
+            CoreException thrown = assertThrows(CoreException.class, () -> Coupon.of(cmd));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "할인 정책은 필수입니다."));
+        }
+
+        @DisplayName("최소 주문 금액이 null이면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenMinimumOrderAmountIsNull() {
+            String name = "루퍼스 쿠폰";
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+            Integer expireHours = 24;
+            Long remainingQuantity = 100L;
+            CouponCommand.Create cmd = new CouponCommand.Create(name, discountPolicy, null, expireHours, remainingQuantity);
+
+            CoreException thrown = assertThrows(CoreException.class, () -> Coupon.of(cmd));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "최소 주문 금액은 필수입니다."));
+        }
+
+        @DisplayName("최소 주문 금액이 0보다 작으면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenMinimumOrderAmountIsLessThanZero() {
+            String name = "루퍼스 쿠폰";
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+            BigDecimal minimumOrderAmount = new BigDecimal("-1");
+            Integer expireHours = 24;
+            Long remainingQuantity = 100L;
+            CouponCommand.Create cmd = new CouponCommand.Create(name, discountPolicy, minimumOrderAmount, expireHours, remainingQuantity);
+
+            CoreException thrown = assertThrows(CoreException.class, () -> Coupon.of(cmd));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "쿠폰을 적용하기 위한 최소 주문 금액은 0 이상이어야 합니다."));
+        }
+
+        @DisplayName("유효 시간이 null이거나 1시간 미만이면, BAD_REQUEST 예외가 발생한다.")
+        @NullSource
+        @ValueSource(ints = {0, -1})
+        @ParameterizedTest
+        void throwBadRequestException_whenExpireHoursIsNullOrLessThanOne(Integer expireHours) {
+            String name = "루퍼스 쿠폰";
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+            BigDecimal minimumOrderAmount = BigDecimal.ZERO;
+            Long remainingQuantity = 100L;
+            CouponCommand.Create cmd = new CouponCommand.Create(name, discountPolicy, minimumOrderAmount, expireHours, remainingQuantity);
+
+            CoreException thrown = assertThrows(CoreException.class, () -> Coupon.of(cmd));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "쿠폰 유효 시간은 1시간 이상이어야 합니다."));
+        }
+
+        @DisplayName("쿠폰 남은 수량이 null이거나 0보다 작으면, BAD_REQUEST 예외가 발생한다.")
+        @NullSource
+        @ValueSource(longs = {-1})
+        @ParameterizedTest
+        void throwBadRequestException_whenRemainingQuantityIsNullOrLessThanZero(Long remainingQuantity) {
+            String name = "루퍼스 쿠폰";
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+            BigDecimal minimumOrderAmount = BigDecimal.ZERO;
+            Integer expireHours = 24;
+            CouponCommand.Create cmd = new CouponCommand.Create(name, discountPolicy, minimumOrderAmount, expireHours, remainingQuantity);
+
+            CoreException thrown = assertThrows(CoreException.class, () -> Coupon.of(cmd));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "쿠폰 수량은 0 이상이어야 합니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰을 발급할 시,")
+    class Issue {
+        @DisplayName("쿠폰 수량이 0보다 작으면, CONFLICT 예외가 발생한다.")
+        @Test
+        void throwConflictException_whenRemainingQuantityIsZero() {
+            String name = "루퍼스 쿠폰";
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+            BigDecimal minimumOrderAmount = BigDecimal.ZERO;
+            Integer expireHours = 24;
+            Coupon coupon = Coupon.of(new CouponCommand.Create(name, discountPolicy, minimumOrderAmount, expireHours, 0L));
+
+            CoreException thrown = assertThrows(CoreException.class, () -> coupon.issue(1L, LocalDateTime.now()));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.CONFLICT, "쿠폰이 모두 소진되었습니다."));
+        }
+
+        @DisplayName("남은 쿠폰 수량이 감소하고, 발급 쿠폰 수량은 증가힌다.")
+        @Test
+        void decreaseRemainingQuantity_whenIssueCoupon() {
+            String name = "루퍼스 쿠폰";
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+            BigDecimal minimumOrderAmount = BigDecimal.ZERO;
+            Integer expireHours = 24;
+            Long initialRemainingQuantity = 10L;
+            Coupon coupon = Coupon.of(new CouponCommand.Create(name, discountPolicy, minimumOrderAmount, expireHours, initialRemainingQuantity));
+
+            UserCoupon userCoupon = coupon.issue(1L, LocalDateTime.now());
+
+            assertThat(userCoupon.getUserId()).isEqualTo(1L);
+            assertThat(coupon.getRemainingQuantity()).isEqualTo(initialRemainingQuantity - 1);
+            assertThat(coupon.getIssuedQuantity()).isEqualTo(1L);
+        }
+
+        @DisplayName("유저 쿠폰이 발급된다.")
+        @Test
+        void issueUserCoupon_whenIssueCoupon() {
+            String name = "루퍼스 쿠폰";
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+            BigDecimal minimumOrderAmount = BigDecimal.ZERO;
+            Integer expireHours = 24;
+            Long initialRemainingQuantity = 10L;
+            Coupon coupon = Coupon.of(new CouponCommand.Create(name, discountPolicy, minimumOrderAmount, expireHours, initialRemainingQuantity));
+            LocalDateTime issuedAt = LocalDateTime.now();
+
+            UserCoupon userCoupon = coupon.issue(1L, issuedAt);
+
+            assertThat(userCoupon).isNotNull();
+            assertThat(userCoupon.getUserId()).isEqualTo(1L);
+            assertThat(userCoupon.getDiscountPolicy()).isEqualTo(coupon.getDiscountPolicy());
+            assertThat(userCoupon.getUsedAt()).isNull();
+            assertThat(userCoupon.getExpiredAt()).isEqualTo(issuedAt.plusHours(coupon.getExpireHours()));
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/DiscountPolicyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/DiscountPolicyTest.java
@@ -1,0 +1,74 @@
+package com.loopers.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DiscountPolicyTest {
+
+    @Nested
+    @DisplayName("할인 정책 생성 시,")
+    class Create {
+        @DisplayName("할인 금액 또는 할인율이 null이면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenValueIsNull() {
+            BigDecimal value = null;
+            DiscountPolicy.Type type = DiscountPolicy.Type.FIXED;
+
+            CoreException thrown = assertThrows(CoreException.class, () -> new DiscountPolicy(value, type));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "할인 금액 또는 할인율은 필수입니다."));
+        }
+
+        @DisplayName("쿠폰 유형이 null이면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenTypeIsNull() {
+            BigDecimal value = BigDecimal.TEN;
+            DiscountPolicy.Type type = null;
+
+            CoreException thrown = assertThrows(CoreException.class, () -> new DiscountPolicy(value, type));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "쿠폰 유형은 필수입니다."));
+        }
+
+        @DisplayName("정률 쿠폰의 할인율이 0 이하이거나 1보다 크면, BAD_REQUEST 예외가 발생한다.")
+        @ValueSource(strings = {"-1", "0", "1.01"})
+        @ParameterizedTest
+        void throwBadRequestException_whenRateIsZeroOrNegative(String value) {
+            BigDecimal discountValue = new BigDecimal(value);
+            DiscountPolicy.Type type = DiscountPolicy.Type.RATE;
+
+            CoreException thrown = assertThrows(CoreException.class, () -> new DiscountPolicy(discountValue, type));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "할인율은 0보다 크고 1 이하이어야 합니다."));
+        }
+
+        @DisplayName("정액 쿠폰의 할인 금액이 0 이하이면, BAD_REQUEST 예외가 발생한다.")
+        @ValueSource(strings = {"-1", "0"})
+        @ParameterizedTest
+        void throwBadRequestException_whenFixedDiscountIsZeroOrNegative(String value) {
+            BigDecimal discountValue = new BigDecimal(value);
+            DiscountPolicy.Type type = DiscountPolicy.Type.FIXED;
+
+            CoreException thrown = assertThrows(CoreException.class, () -> new DiscountPolicy(discountValue, type));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "고정 할인 금액 은 0보다 커야 합니다."));
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/FixedDiscountPolicyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/FixedDiscountPolicyTest.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FixedDiscountPolicyTest {
+
+    @DisplayName("정액 할인 적용 시, 할인 금액이 올바르게 계산되어야 한다.")
+    @Test
+    void returnsCorrectDiscountAmount() {
+        DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000"), DiscountPolicy.Type.FIXED);
+        FixedDiscountStrategy fixedDiscountPolicy = new FixedDiscountStrategy(discountPolicy);
+        BigDecimal originalAmount = new BigDecimal("5000");
+
+        BigDecimal paymentAmount = fixedDiscountPolicy.discount(originalAmount);
+
+        assertThat(paymentAmount).isEqualTo(new BigDecimal("4000"));
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/RateDiscountPolicyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/RateDiscountPolicyTest.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RateDiscountPolicyTest {
+
+    @DisplayName("정률 할인 적용 시, 올바른 할인 금액을 반환한다.")
+    @Test
+    void returnCorrectDiscountAmount() {
+        DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("0.1"), DiscountPolicy.Type.RATE);
+        RateDiscountStrategy rateDiscountPolicy = new RateDiscountStrategy(discountPolicy);
+        BigDecimal amount = new BigDecimal("1000");
+
+        BigDecimal paymentAmount = rateDiscountPolicy.discount(amount);
+
+        assertThat(paymentAmount).isEqualTo(new BigDecimal("900"));
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/UserCouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/UserCouponTest.java
@@ -1,0 +1,158 @@
+package com.loopers.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class UserCouponTest {
+    @Nested
+    @DisplayName("유저 쿠폰 생성 시,")
+    class Create {
+        @DisplayName("사용자 ID가 null이면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenUserIdIsNull() {
+            Long userId = null;
+            Long couponId = 1L;
+            LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000.00"), DiscountPolicy.Type.FIXED);
+
+            Exception exception = assertThrows(CoreException.class, () -> UserCoupon.of(userId, couponId, discountPolicy, expiredAt));
+
+            assertThat(exception)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "사용자 ID가 존재하지 않습니다."));
+        }
+
+        @DisplayName("쿠폰 ID가 null이면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenCouponIdIsNull() {
+            Long userId = 1L;
+            Long couponId = null;
+            LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000.00"), DiscountPolicy.Type.FIXED);
+
+            Exception exception = assertThrows(CoreException.class, () -> UserCoupon.of(userId, couponId, discountPolicy, expiredAt));
+
+            assertThat(exception)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "쿠폰 ID가 존재하지 않습니다."));
+        }
+
+        @DisplayName("만료 날짜가 null이면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenExpiredAtIsNull() {
+            Long userId = 1L;
+            Long couponId = 1L;
+            LocalDateTime expiredAt = null;
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000.00"), DiscountPolicy.Type.FIXED);
+
+            Exception exception = assertThrows(CoreException.class, () -> UserCoupon.of(userId, couponId, discountPolicy, expiredAt));
+
+            assertThat(exception)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "쿠폰 만료 날짜가 존재하지 않습니다."));
+        }
+
+        @DisplayName("할인 정책이 null이면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenDiscountPolicyIsNull() {
+            Long userId = 1L;
+            Long couponId = 1L;
+            LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+
+            Exception exception = assertThrows(CoreException.class, () -> UserCoupon.of(userId, couponId, null, expiredAt));
+
+            assertThat(exception)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "할인 정책이 존재하지 않습니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 쿠폰 사용 시,")
+    class Use {
+        @DisplayName("이미 사용한 쿠폰을 사용하려고 하면, CONFLICT 예외가 발생한다.")
+        @Test
+        void throwConflictException_whenCouponAlreadyUsed() {
+            Long userId = 1L;
+            Long couponId = 1L;
+            LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000.00"), DiscountPolicy.Type.FIXED);
+            UserCoupon userCoupon = UserCoupon.of(userId, couponId, discountPolicy, expiredAt);
+            userCoupon.use(LocalDateTime.now());
+
+            Exception exception = assertThrows(CoreException.class, () -> userCoupon.use(LocalDateTime.now()));
+
+            assertThat(exception)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.CONFLICT, "이미 사용한 쿠폰입니다."));
+        }
+
+        @DisplayName("만료된 쿠폰을 사용하려고 하면, CONFLICT 예외가 발생한다.")
+        @Test
+        void throwConflictException_whenCouponExpired() {
+            Long userId = 1L;
+            Long couponId = 1L;
+            LocalDateTime expiredAt = LocalDateTime.now().minusDays(1);
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000.00"), DiscountPolicy.Type.FIXED);
+            UserCoupon userCoupon = UserCoupon.of(userId, couponId, discountPolicy, expiredAt);
+
+            Exception exception = assertThrows(CoreException.class, () -> userCoupon.use(LocalDateTime.now()));
+
+            assertThat(exception)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.CONFLICT, "이미 만료된 쿠폰입니다."));
+        }
+
+        @DisplayName("유효한 쿠폰을 사용하면, 사용 시간이 기록된다.")
+        @Test
+        void recordUsedAt_whenCouponIsValid() {
+            Long userId = 1L;
+            Long couponId = 1L;
+            LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+            DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000.00"), DiscountPolicy.Type.FIXED);
+            UserCoupon userCoupon = UserCoupon.of(userId, couponId, discountPolicy, expiredAt);
+
+            LocalDateTime usedAt = LocalDateTime.now();
+            userCoupon.use(usedAt);
+
+            assertThat(userCoupon.getUsedAt()).isEqualTo(usedAt);
+        }
+    }
+
+    @DisplayName("쿠폰이 사용되었는지 확인할 때, 이미 사용된 경우라면 false를 반환한다.")
+    @Test
+    void returnFalse_whenUserCouponUsed() {
+        Long userId = 1L;
+        Long couponId = 1L;
+        LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+        DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000.00"), DiscountPolicy.Type.FIXED);
+        UserCoupon userCoupon = UserCoupon.of(userId, couponId, discountPolicy, expiredAt);
+        userCoupon.use(LocalDateTime.now());
+
+        boolean isUsed = userCoupon.isUsed();
+
+        assertThat(isUsed).isTrue();
+    }
+
+    @DisplayName("쿠폰이 만료되었는지 확인할 때, 만료된 경우라면 true를 반환한다.")
+    @Test
+    void returnTrue_whenUserCouponExpired() {
+        Long userId = 1L;
+        Long couponId = 1L;
+        LocalDateTime expiredAt = LocalDateTime.now().minusDays(1);
+        DiscountPolicy discountPolicy = new DiscountPolicy(new BigDecimal("1000.00"), DiscountPolicy.Type.FIXED);
+        UserCoupon userCoupon = UserCoupon.of(userId, couponId, discountPolicy, expiredAt);
+
+        boolean isExpired = userCoupon.isExpired(LocalDateTime.now());
+
+        assertThat(isExpired).isTrue();
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderLineTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderLineTest.java
@@ -60,7 +60,7 @@ class OrderLineTest {
 
             assertThat(orderLine.getProductId()).isEqualTo(line.productId());
             assertThat(orderLine.getQuantity()).isEqualTo(line.quantity());
-            assertThat(orderLine.getAmount()).isEqualTo(line.unitPrice());
+            assertThat(orderLine.getAmount()).isEqualTo(line.amount());
         }
 
         @DisplayName("가격이 음수라면, BAD_REQUEST 예외를 반환한다.")
@@ -81,7 +81,7 @@ class OrderLineTest {
 
             assertThat(orderLine.getProductId()).isEqualTo(line.productId());
             assertThat(orderLine.getQuantity()).isEqualTo(line.quantity());
-            assertThat(orderLine.getAmount()).isEqualTo(line.unitPrice());
+            assertThat(orderLine.getAmount()).isEqualTo(line.amount());
         }
     }
 
@@ -104,8 +104,8 @@ class OrderLineTest {
         @Test
         void createOrderLine_withMergedLines() {
             List<OrderCommand.Line> lines = List.of(
-                    new Line(1L, 2L, new BigDecimal("1000")),
-                    new Line(1L, 3L, new BigDecimal("1000")),
+                    new Line(1L, 2L, new BigDecimal("2000")),
+                    new Line(1L, 3L, new BigDecimal("3000")),
                     new Line(2L, 1L, new BigDecimal("2000"))
             );
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderPaymentTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderPaymentTest.java
@@ -16,10 +16,30 @@ class OrderPaymentTest {
     @DisplayName("결제 정보 생성 시,")
     class Create {
 
+        @DisplayName("총 금액이 null이면, BAD_REQUEST 예외를 발생시킨다.")
+        @Test
+        void throwBadRequestException_whenOriginalAmountIsNull() {
+            CoreException thrown = assertThrows(CoreException.class, () -> new OrderPayment(null, BigDecimal.valueOf(1000)));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "총 금액이 존재하지 않습니다."));
+        }
+
+        @DisplayName("총 금액이 0 미만이면, BAD_REQUEST 예외를 발생시킨다.")
+        @Test
+        void throwBadRequestException_whenOriginalAmountIsNegative() {
+            CoreException thrown = assertThrows(CoreException.class, () -> new OrderPayment(BigDecimal.valueOf(-1), BigDecimal.valueOf(1000)));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "총 금액은 0 이상이어야 합니다."));
+        }
+
         @DisplayName("결제 금액이 null이면, BAD_REQUEST 예외를 발생시킨다.")
         @Test
         void throwBadRequestException_whenTotalAmountIsNull() {
-            CoreException thrown = assertThrows(CoreException.class, () -> new OrderPayment(null));
+            CoreException thrown = assertThrows(CoreException.class, () -> new OrderPayment(BigDecimal.valueOf(1000), null));
 
             assertThat(thrown)
                     .usingRecursiveComparison()
@@ -29,39 +49,11 @@ class OrderPaymentTest {
         @DisplayName("결제 금액이 0 미만이면, BAD_REQUEST 예외를 발생시킨다.")
         @Test
         void throwBadRequestException_whenTotalAmountIsNegative() {
-            CoreException thrown = assertThrows(CoreException.class, () -> new OrderPayment(BigDecimal.valueOf(-1)));
+            CoreException thrown = assertThrows(CoreException.class, () -> new OrderPayment(BigDecimal.valueOf(1000), BigDecimal.valueOf(-1)));
 
             assertThat(thrown)
                     .usingRecursiveComparison()
                     .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "결제 금액은 0 이상이어야 합니다."));
-        }
-    }
-
-    @Nested
-    @DisplayName("결제 금액을 추가할 때,")
-    class Add {
-        @DisplayName("추가 금액이 null이면, BAD_REQUEST 예외를 발생시킨다.")
-        @Test
-        void throwBadRequestException_whenAmountIsNull() {
-            OrderPayment orderPayment = new OrderPayment(BigDecimal.valueOf(1000));
-
-            CoreException thrown = assertThrows(CoreException.class, () -> orderPayment.add(null));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "추가 금액은 0 이상이어야 합니다."));
-        }
-
-        @DisplayName("추가 금액이 0 미만이면, BAD_REQUEST 예외를 발생시킨다.")
-        @Test
-        void throwBadRequestException_whenAmountIsNegative() {
-            OrderPayment orderPayment = new OrderPayment(BigDecimal.valueOf(1000));
-
-            CoreException thrown = assertThrows(CoreException.class, () -> orderPayment.add(BigDecimal.valueOf(-1)));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "추가 금액은 0 이상이어야 합니다."));
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -7,7 +7,6 @@ import com.loopers.infrastructure.order.OrderJpaRepository;
 import com.loopers.utils.DatabaseCleanUp;
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -50,7 +49,7 @@ class OrderServiceIntegrationTest {
                     "101호",
                     "배송 요청사항"
             );
-            OrderCommand.Order command = new OrderCommand.Order(1L, lines, delivery);
+            OrderCommand.Order command = new OrderCommand.Order(1L, lines, delivery, BigDecimal.valueOf(3000), BigDecimal.valueOf(2000));
 
             OrderInfo orderInfo = orderService.order(command);
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
@@ -1,6 +1,5 @@
 package com.loopers.domain.order;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -11,8 +10,6 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class OrderTest {
 
@@ -24,12 +21,42 @@ class OrderTest {
         @Test
         void throwBadRequestException_whenUserIdIsNull() {
             OrderCommand.Delivery delivery = new OrderCommand.Delivery("황건하", "010-1234-5678", "서울특별시 강남구 강남대로 지하396", "강남역 지하 XX", "요구사항");
+            List<OrderCommand.Line> lines = List.of(new OrderCommand.Line(1L, 2L, new BigDecimal("3000")));
+            OrderCommand.Order cmd = new OrderCommand.Order(null, lines, delivery, new BigDecimal("6000"), new BigDecimal("6000"));
 
-            CoreException thrown = assertThrows(CoreException.class, () -> Order.of(null, delivery));
+            CoreException thrown = assertThrows(CoreException.class, () -> Order.of(cmd));
 
             assertThat(thrown)
                     .usingRecursiveComparison()
                     .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "사용자 ID가 존재하지 않습니다."));
+        }
+
+        @DisplayName("총 금액과 결제 금액이 저장된다.")
+        @Test
+        void order_withOrderPayment() {
+            OrderCommand.Delivery delivery = new OrderCommand.Delivery("황건하", "010-1234-5678", "서울특별시 강남구 강남대로 지하396", "강남역 지하 XX", "요구사항");
+            List<OrderCommand.Line> lines = List.of(new OrderCommand.Line(1L, 2L, new BigDecimal("3000")));
+            OrderCommand.Order cmd = new OrderCommand.Order(1L, lines, delivery, new BigDecimal("6000"), new BigDecimal("4000"));
+
+            Order order = Order.of(cmd);
+
+            assertThat(order.getOrderPayment().getPaymentAmount()).isEqualTo(new BigDecimal("4000"));
+            assertThat(order.getOrderPayment().getOriginalAmount()).isEqualTo(new BigDecimal("6000"));
+        }
+
+        @DisplayName("주문 내부에 주문 항목들이 존재한다.")
+        @Test
+        void order_withOrderLines() {
+            OrderCommand.Delivery delivery = new OrderCommand.Delivery("황건하", "010-1234-5678", "서울특별시 강남구 강남대로 지하396", "강남역 지하 XX", "요구사항");
+            List<OrderCommand.Line> lines = List.of(new OrderCommand.Line(1L, 2L, new BigDecimal("3000")));
+            OrderCommand.Order cmd = new OrderCommand.Order(1L, lines, delivery, new BigDecimal("6000"), new BigDecimal("6000"));
+
+            Order order = Order.of(cmd);
+
+            assertThat(order.getOrderLines()).hasSize(1);
+            assertThat(order.getOrderLines().get(0).getProductId()).isEqualTo(1L);
+            assertThat(order.getOrderLines().get(0).getQuantity()).isEqualTo(2L);
+            assertThat(order.getOrderLines().get(0).getAmount()).isEqualTo(new BigDecimal("6000"));
         }
     }
 
@@ -37,23 +64,15 @@ class OrderTest {
     @Test
     void throwBadRequestException_whenOrderLineIsNull() {
         OrderCommand.Delivery delivery = new OrderCommand.Delivery("황건하", "010-1234-5678", "서울특별시 강남구 강남대로 지하396", "강남역 지하 XX", "요구사항");
-        Order order = Order.of(1L, delivery);
+        List<OrderCommand.Line> lines = List.of(new OrderCommand.Line(1L, 2L, new BigDecimal("3000")));
+        OrderCommand.Order cmd = new OrderCommand.Order(1L, lines, delivery, new BigDecimal("6000"), new BigDecimal("6000"));
+
+        Order order = Order.of(cmd);
 
         CoreException thrown = assertThrows(CoreException.class, () -> order.addLine(null));
 
         assertThat(thrown)
                 .usingRecursiveComparison()
                 .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "주문 항목이 존재하지 않습니다."));
-    }
-
-    @DisplayName("주문 항목 추가 시, 결제 금액이 증가한다.")
-    @Test
-    void increasePaymentAmount_whenAddLine() {
-        OrderCommand.Delivery delivery = new OrderCommand.Delivery("황건하", "010-1234-5678", "서울특별시 강남구 강남대로 지하396", "강남역 지하 XX", "요구사항");
-        Order order = Order.of(1L, delivery);
-
-        order.addLine(OrderLine.from(new OrderCommand.Line(1L, 2L, new BigDecimal("3000"))));
-
-        assertThat(order.getOrderPayment().getPaymentAmount()).isEqualTo(new BigDecimal("6000"));
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
@@ -49,14 +49,14 @@ class OrderTest {
         void order_withOrderLines() {
             OrderCommand.Delivery delivery = new OrderCommand.Delivery("황건하", "010-1234-5678", "서울특별시 강남구 강남대로 지하396", "강남역 지하 XX", "요구사항");
             List<OrderCommand.Line> lines = List.of(new OrderCommand.Line(1L, 2L, new BigDecimal("3000")));
-            OrderCommand.Order cmd = new OrderCommand.Order(1L, lines, delivery, new BigDecimal("6000"), new BigDecimal("6000"));
+            OrderCommand.Order cmd = new OrderCommand.Order(1L, lines, delivery, new BigDecimal("3000"), new BigDecimal("3000"));
 
             Order order = Order.of(cmd);
 
             assertThat(order.getOrderLines()).hasSize(1);
             assertThat(order.getOrderLines().get(0).getProductId()).isEqualTo(1L);
             assertThat(order.getOrderLines().get(0).getQuantity()).isEqualTo(2L);
-            assertThat(order.getOrderLines().get(0).getAmount()).isEqualTo(new BigDecimal("6000"));
+            assertThat(order.getOrderLines().get(0).getAmount()).isEqualTo(new BigDecimal("3000"));
         }
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceTest.java
@@ -70,7 +70,7 @@ class PointServiceTest {
         void throwsNotFoundException_whenPointDoesNotExist() {
 
             long nonExistUserId = 1L;
-            given(pointRepository.findByUserId(nonExistUserId))
+            given(pointRepository.findByUserIdWithLock(nonExistUserId))
                     .willReturn(Optional.empty());
 
             assertThatThrownBy(() -> pointService.charge(new PointCommand.Charge(nonExistUserId, 1000L)))
@@ -85,7 +85,7 @@ class PointServiceTest {
             Point point = Point.from(userId);
             long initPoint = 500L;
             point.charge(initPoint);
-            given(pointRepository.findByUserId(userId))
+            given(pointRepository.findByUserIdWithLock(userId))
                     .willReturn(Optional.of(point));
             long chargePoint = 1000L;
 
@@ -101,7 +101,7 @@ class PointServiceTest {
             long chargePoint = 1000L;
             Point point = Point.from(userId);
 
-            given(pointRepository.findByUserId(userId))
+            given(pointRepository.findByUserIdWithLock(userId))
                     .willReturn(Optional.of(point));
 
             pointService.charge(new PointCommand.Charge(userId, chargePoint));
@@ -122,7 +122,7 @@ class PointServiceTest {
         @Test
         void throwsNotFoundException_whenPointDoesNotExist() {
             long nonExistUserId = 1L;
-            given(pointRepository.findByUserId(nonExistUserId))
+            given(pointRepository.findByUserIdWithLock(nonExistUserId))
                     .willReturn(Optional.empty());
 
             CoreException thrown = assertThrows(CoreException.class, () -> pointService.use(new PointCommand.Use(nonExistUserId, 1000L)));
@@ -141,7 +141,7 @@ class PointServiceTest {
             Point point = Point.from(userId);
             point.charge(initialPoint);
 
-            given(pointRepository.findByUserId(userId))
+            given(pointRepository.findByUserIdWithLock(userId))
                     .willReturn(Optional.of(point));
 
             PointInfo pointInfo = pointService.use(new PointCommand.Use(userId, usePoint));
@@ -158,7 +158,7 @@ class PointServiceTest {
             Point point = Point.from(userId);
             point.charge(initialPoint);
 
-            given(pointRepository.findByUserId(userId))
+            given(pointRepository.findByUserIdWithLock(userId))
                     .willReturn(Optional.of(point));
 
             pointService.use(new PointCommand.Use(userId, usePoint));

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.loopers.domain.PageResponse;
+import com.loopers.domain.product.ProductCommand.Purchasable;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import java.math.BigDecimal;
@@ -56,7 +57,7 @@ class ProductServiceTest {
         @NullAndEmptySource
         @ParameterizedTest(name = "productIds = {0}")
         void throwBadRequestException_whenProductIdsIsEmpty(Set<Long> productIds) {
-            CoreException thrown = assertThrows(CoreException.class, () -> productService.getPurchasableProducts(new ProductCommand.GetProducts(productIds)));
+            CoreException thrown = assertThrows(CoreException.class, () -> productService.getPurchasableProducts(new Purchasable(productIds)));
 
             assertThat(thrown)
                     .usingRecursiveComparison()
@@ -72,7 +73,7 @@ class ProductServiceTest {
             given(productRepository.findByIds(productIds))
                     .willReturn(List.of(product1, product2));
 
-            List<ProductInfo> result = productService.getPurchasableProducts(new ProductCommand.GetProducts(productIds));
+            List<ProductInfo> result = productService.getPurchasableProducts(new Purchasable(productIds));
 
             assertThat(result).hasSize(1);
             assertThat(result.get(0).name()).isEqualTo("Product 1");

--- a/apps/commerce-api/src/test/java/com/loopers/domain/stock/StockServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/stock/StockServiceIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.loopers.domain.stock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.loopers.utils.DatabaseCleanUp;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class StockServiceIntegrationTest {
+
+    @Autowired
+    private StockService stockService;
+    @Autowired
+    private StockRepository stockRepository;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("재고 차감 시,")
+    class Deduct {
+
+        @DisplayName("동시에 재고 차감을 요청해도, 재고는 정확히 차감된다.")
+        @Test
+        void deduct_concurrent() throws InterruptedException {
+            stockRepository.save(Stock.create(new StockCommand.Create(1L, 100L)));
+            int threadCount = 10;
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            for (int i = 0; i < threadCount; i++) {
+                executor.submit(() -> {
+                    try {
+                        stockService.deduct(new StockCommand.Deduct(1L, 10L));
+                    } catch (Exception e) {
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            Stock stock = stockRepository.findByProductId(1L).orElseThrow();
+            assertThat(stock.getQuantity().getValue()).isEqualTo(0L);
+        }
+    }
+
+    @Nested
+    @DisplayName("여러 재고 차감 시,")
+    class DeductAll {
+        @DisplayName("동시에 재고 차감을 요청해도, 재고는 정확히 차감된다.")
+        @Test
+        void deductAll_concurrent() throws InterruptedException {
+            stockRepository.save(Stock.create(new StockCommand.Create(1L, 100L)));
+            stockRepository.save(Stock.create(new StockCommand.Create(2L, 100L)));
+            stockRepository.save(Stock.create(new StockCommand.Create(3L, 100L)));
+            stockRepository.save(Stock.create(new StockCommand.Create(4L, 100L)));
+
+            int threadCount = 10;
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+
+            for (int i = 0; i < threadCount; i++) {
+                List<StockCommand.Deduct> commands = (i % 2 == 0)
+                        ? List.of(new StockCommand.Deduct(1L, 10L), new StockCommand.Deduct(2L, 10L), new StockCommand.Deduct(3L, 10L), new StockCommand.Deduct(4L, 10L))
+                        : List.of(new StockCommand.Deduct(4L, 10L), new StockCommand.Deduct(3L, 10L), new StockCommand.Deduct(2L, 10L), new StockCommand.Deduct(1L, 10L));
+                executor.submit(() -> {
+                    try {
+                        stockService.deductAll(commands);
+                    } catch (Exception e) {
+                        System.out.println("Error : " + e.getMessage());
+                    }
+                    finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            Stock stock1 = stockRepository.findByProductId(1L).orElseThrow();
+            assertThat(stock1.getQuantity().getValue()).isEqualTo(0L);
+            Stock stock2 = stockRepository.findByProductId(2L).orElseThrow();
+            assertThat(stock2.getQuantity().getValue()).isEqualTo(0L);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/stock/StockServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/stock/StockServiceTest.java
@@ -48,7 +48,7 @@ class StockServiceTest {
         void throwNotFoundException_whenStockDoesNotExist() {
             Long productId = 1L;
             Long quantity = 10L;
-            given(stockRepository.findByProductId(productId))
+            given(stockRepository.findByProductIdWithLock(productId))
                     .willReturn(Optional.empty());
 
             CoreException thrown = assertThrows(CoreException.class, () -> stockService.deduct(new StockCommand.Deduct(productId, quantity)));


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

- 동시성 문제 해결
  - 포인트 차감/충전
  - 재고 차감
  - 상품 좋아요 수 증가/감소
  - 쿠폰 사용
- 쿠폰 기능
  - 주문 시, 쿠폰 사용
  - 쿠폰 발급

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

## 주문과 결제
현재 제가 구현한 코드에서는 포인트를 통해서만 구매할 수 있기에, 주문과 결제는 하나의 트랜잭션에서 처리되는 방향으로 되어 있습니다.
그러다 실제 PG를 통한 결제를 고려해보면 주문과 결제는 분리되어야 하는게 맞다고 생각이 드는데, 추후 리팩토링을 하려는데 여기서 궁금한 점이 있습니다.

### 1️⃣ 주문 생성과 결제 처리
주문과 결제가 분리된다면, 주문 API와 결제 API가 분리되고, PG를 통해 결제가 완료되면 결제 API가 수행되는 것으로 생각했습니다.
이때 사용자가 배송지 정보 등을 입력하고 '결제하기'를 누르면, 주문 API가 수행되어 `PENDING` 상태의 주문을 만들고, PG 창으로 넘어가는 것으로 이해하고 있습니다..!

이때 만약 **사용자가 결제하지 않고 그냥 창을 닫는다면, 생성된 주문 레코드는 그대로 남아있는 걸까요? 아니면 추후 PENDING 상태의 레코드에 대한 처리가 수행되는지 궁금합니다!**
혹은 제가 **주문과 결제에 대한 구분이 잘못되어서 위와 같은 흐름 자체가 잘못된 것인지** 궁금합니다!

### 2️⃣ 주문과 결제는 각각 무엇을 수행해야할까?
주문과 결제를 나누어 생각하니, **재고/포인트 차감 시점이 고민**되는 것 같습니다.
만약 주문에서 재고나 포인트를 차감할 경우, 사용자가 PG창을 닫아버리는 상황에서 문제가 될 것 같습니다.
그런데 결제에서 재고/포인트 차감을 하자니, 재고나 포인트가 부족한 상황이면 다시 환불을 해줘야합니다. 만약 '100원 특가'와 같은 이벤트가 있으면 사용자가 많이 몰리게 될텐데, 그러면 많은 사용자가 결제하고 다시 환불받아야 하는 경우가 발생할 것 같습니다..
이러한 상황에서, **실제 주문과 결제는 각각 어떤 책임을 들고가는게 맞을지** 궁금합니다! 주문 시점에 간단한 검증이 들어가는걸까요?

### 3️⃣ 운영 테스트
이번 주차에서 테스트 코드를 통해서 구현한 코드가 동시성 이슈를 제어하였는지 확인할 수 있었습니다.
근데 서비스를 사용하는 사람 입장에서 '그렇다면, 몇 명까지 버틸 수 있나요?'라는 질문이 자연스럽게 들어올 것 같습니다.
보통 **이러한 부분을 테스트할 때, Alen님은 어떻게 테스트하시고, 어떤 툴을 사용하시는지** 궁금합니다!

### 4️⃣ 쿠폰은 `주문 생성 전`인지, `주문 생성 후`인지 궁금합니다.
이번 쿠폰에서 저는 `상품 조회 (- 쿠폰 적용) - 주문 생성 - ...` 흐름으로 되어 있습니다.
쿠폰 적용이 없을 때에는, 주문 생성 시점에 주문 상품을 넣으면서 금액을 계산하였습니다. 그런데 쿠폰이 들어오고, 정률 쿠폰인 경우에 총 금액을 알아야 할인 금액도 알 수 있습니다.
그래서 사실 `상품 조회 - 총 금액 계산 - 쿠폰 적용(할인 금액 반환) - 주문 생성(총 금액, 할인 금액을 받고 그대로 사용)- ...`로 이루어져 있습니다.
그런데 '주문에 쿠폰을 적용한다.'라는 문장이 더 익숙해서 그런지, 쿠폰을 적용하고 주문을 생성한다는 것이 어색한 것 같습니다..!
만약 '주문에 쿠폰을 적용한다.'라는 순서로 가려면 `주문 생성 - (쿠폰 사용 - 주문 업데이트) - ...`가 될 것 같습니다.
근데 제가 이 프로젝트에서 적용하고 있는 컨벤션은 'Facade 단에서 도메인을 직접 받지 않도록 한다.'로 생각하고 코드를 작성하고 있습니다. 그래서 생성된 주문에 할인을 적용하려면 다시 주문 서비스로 가서 `orderService.applyDiscount(~)`와 같은 형식으로 다시 OrderService에 요청해야 합니다. 이때 OrderCouponService와 같은 도메인 서비스를 통해 처리하면 되지 않을까 싶은데, Facade 단에서 도메인을 가질 수 없도록 규칙을 정해서 일단 배제하였습니다.
**쿠폰이 주문 생성 전에 적용된다는 것은 제가 현실 세계와 코드를 너무 동일시하려고 해서 그런걸까요?** 아니면 제가 정한 스스로의 컨벤션에서는 어쩔 수 없는 것인지 Alen님 의견이 궁금합니다!

### 5️⃣ 실무에서 동시성 처리가 필요한 경우 DB 외 다른 처리도 하는지 궁금합니다!
이번에 동시성 문제를 처리할 때, 낙관적/비관적 락을 사용하였습니다. 두 방식 모두 DB와 직접적으로 연관된 기능인데, 성능적으로 문제가 되진 않을까 싶습니다..!
실무에서는 이 외와 같은 동시성 제어 이슈가 있을 때, 일반적으로 DB 락 이 외에 어떠한 추가적인 방법을 사용하는지 궁금합니다!



## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

관련 커밋을 첨부하였습니다!

### 🗞️ Coupon 도메인

- [x]  쿠폰은 사용자가 소유하고 있으며, 이미 사용된 쿠폰은 사용할 수 없어야 한다.
- [x]  쿠폰 종류는 정액 / 정률로 구분되며, 각 적용 로직을 구현하였다.
- [x]  각 발급된 쿠폰은 최대 한번만 사용될 수 있다.

### 🧾 **주문**

- [x]  주문 전체 흐름에 대해 원자성이 보장되어야 한다. 
- [x]  사용 불가능하거나 존재하지 않는 쿠폰일 경우 주문은 실패해야 한다.
- [x]  재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다.
- [x]  주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다
- [x]  쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리되어야 한다.
- [x]  주문 성공 시, 모든 처리는 정상 반영되어야 한다.

### 🧪 동시성 테스트

- [x]  동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.
- [x]  동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다.
- [x]  동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감되어야 한다.
- [x]  동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다. 


## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->