### PR TITLE
[volume-10] 주간/월간 랭킹 배치 추가

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -7,7 +7,7 @@ import com.loopers.domain.brand.BrandService;
 import com.loopers.domain.product.ProductCommand;
 import com.loopers.domain.product.ProductInfo;
 import com.loopers.domain.product.ProductService;
-import com.loopers.domain.ranking.RankingCommand.Rankings;
+import com.loopers.domain.ranking.RankingCommand;
 import com.loopers.domain.ranking.RankingInfo;
 import com.loopers.domain.ranking.RankingService;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +22,45 @@ public class RankingFacade {
 
     public PageResponse<RankingResult> getRankProducts(RankingCriteria.Search cri) {
         PageResponse<RankingInfo> rankings = rankingService.getRankings(
-                new Rankings(cri.size(), cri.page(), cri.date()));
+                new RankingCommand.Rankings(cri.size(), cri.page(), cri.date()));
 
         return rankings.map(ranking -> {
+            ProductInfo product = productService.findProduct(new ProductCommand.Find(ranking.productId()));
+            BrandInfo brand = brandService.findBy(new BrandCommand.Find(product.brandId()));
+            return new RankingResult(
+                    product.id(),
+                    brand.name(),
+                    product.name(),
+                    product.price(),
+                    product.status(),
+                    ranking.rank()
+            );
+        });
+    }
+
+    public PageResponse<RankingResult> getWeeklyRankProduct(RankingCriteria.Search cri) {
+        PageResponse<RankingInfo> infos =
+                rankingService.getWeeklyRankings(new RankingCommand.Rankings(cri.size(), cri.page(), cri.date()));
+
+        return infos.map(ranking -> {
+            ProductInfo product = productService.findProduct(new ProductCommand.Find(ranking.productId()));
+            BrandInfo brand = brandService.findBy(new BrandCommand.Find(product.brandId()));
+            return new RankingResult(
+                    product.id(),
+                    brand.name(),
+                    product.name(),
+                    product.price(),
+                    product.status(),
+                    ranking.rank()
+            );
+        });
+    }
+
+    public PageResponse<RankingResult> getMonthlyRankProduct(RankingCriteria.Search cri) {
+        PageResponse<RankingInfo> infos =
+                rankingService.getMonthlyRankings(new RankingCommand.Rankings(cri.size(), cri.page(), cri.date()));
+
+        return infos.map(ranking -> {
             ProductInfo product = productService.findProduct(new ProductCommand.Find(ranking.productId()));
             BrandInfo brand = brandService.findBy(new BrandCommand.Find(product.brandId()));
             return new RankingResult(

--- a/apps/commerce-api/src/main/java/com/loopers/domain/PageResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/PageResponse.java
@@ -28,7 +28,7 @@ public class PageResponse<T> {
 
     private PageResponse(Page<T> page) {
         this.content = page.getContent();
-        this.pageNumber = page.getNumber();
+        this.pageNumber = page.getNumber() + 1;
         this.pageSize = page.getSize();
         this.totalElements = page.getTotalElements();
         this.totalPages = page.getTotalPages();

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MonthlyRankingProductMv.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MonthlyRankingProductMv.java
@@ -1,0 +1,42 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "mv_product_rank_monthly")
+public class MonthlyRankingProductMv {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @Column(name = "ref_product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "monthly_rank", nullable = false)
+    private Integer rank;
+
+    @Column(name = "score", nullable = false)
+    private Double score;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    protected MonthlyRankingProductMv() {
+    }
+
+    public MonthlyRankingProductMv(Long productId, Integer rank, Double score, LocalDate date) {
+        this.productId = productId;
+        this.rank = rank;
+        this.score = score;
+        this.date = date;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingMvRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingMvRepository.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+import org.springframework.data.domain.Page;
+
+public interface RankingMvRepository {
+    Page<WeeklyRankingProductMv> findWeeklyRankingProducts(int page, int size, LocalDate date);
+
+    Page<MonthlyRankingProductMv> findMonthlyRankingProducts(int page, int size, LocalDate date);
+
+    WeeklyRankingProductMv save(WeeklyRankingProductMv mv);
+
+    MonthlyRankingProductMv save(MonthlyRankingProductMv mv);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/WeeklyRankingProductMv.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/WeeklyRankingProductMv.java
@@ -1,0 +1,41 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "mv_product_rank_weekly")
+public class WeeklyRankingProductMv {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "ref_product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "weekly_rank", nullable = false)
+    private Integer rank;
+
+    @Column(name = "score", nullable = false)
+    private Double score;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    protected WeeklyRankingProductMv() {
+    }
+
+    public WeeklyRankingProductMv(Long productId, Integer rank, Double score, LocalDate date) {
+        this.productId = productId;
+        this.rank = rank;
+        this.score = score;
+        this.date = date;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingProductMvJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingProductMvJpaRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MonthlyRankingProductMv;
+import java.time.LocalDate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MonthlyRankingProductMvJpaRepository extends JpaRepository<MonthlyRankingProductMv, Long> {
+    Page<MonthlyRankingProductMv> findByDateOrderByRankAsc(LocalDate date, Pageable pageable);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingMvRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingMvRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MonthlyRankingProductMv;
+import com.loopers.domain.ranking.RankingMvRepository;
+import com.loopers.domain.ranking.WeeklyRankingProductMv;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingMvRepositoryImpl implements RankingMvRepository {
+    private final WeeklyRankingProductMvJpaRepository weeklyJpaRepository;
+    private final MonthlyRankingProductMvJpaRepository monthlyJpaRepository;
+
+    @Override
+    public Page<WeeklyRankingProductMv> findWeeklyRankingProducts(int page, int size, LocalDate date) {
+        PageRequest request = PageRequest.of(page - 1, size, Sort.by(Direction.ASC, "rank"));
+        return weeklyJpaRepository.findByDateOrderByRankAsc(date, request);
+    }
+
+    @Override
+    public Page<MonthlyRankingProductMv> findMonthlyRankingProducts(int page, int size, LocalDate date) {
+        PageRequest request = PageRequest.of(page - 1, size, Sort.by(Direction.ASC, "rank"));
+        return monthlyJpaRepository.findByDateOrderByRankAsc(date, request);
+    }
+
+    @Override
+    public WeeklyRankingProductMv save(WeeklyRankingProductMv mv) {
+        return weeklyJpaRepository.save(mv);
+    }
+
+    @Override
+    public MonthlyRankingProductMv save(MonthlyRankingProductMv mv) {
+        return monthlyJpaRepository.save(mv);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingProductMvJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingProductMvJpaRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.WeeklyRankingProductMv;
+import java.time.LocalDate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeeklyRankingProductMvJpaRepository extends JpaRepository<WeeklyRankingProductMv, Long> {
+    Page<WeeklyRankingProductMv> findByDateOrderByRankAsc(LocalDate date, Pageable pageable);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -4,6 +4,7 @@ import com.loopers.domain.PageResponse;
 import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 
 @Tag(name = "Ranking API", description = "Loopers Ranking API입니다.")
 public interface RankingV1ApiSpec {
@@ -12,4 +13,16 @@ public interface RankingV1ApiSpec {
             description = "랭킹 정보를 조회합니다."
     )
     ApiResponse<PageResponse<RankingV1Dto.RankingResponse>> getRanking(int page, int size);
+
+    @Operation(
+            summary = "주간 랭킹 조회",
+            description = "주간 랭킹 정보를 조회합니다."
+    )
+    ApiResponse<PageResponse<RankingV1Dto.RankingResponse>> getWeeklyRanking(int page, int size, LocalDate date);
+
+    @Operation(
+            summary = "월간 랭킹 조회",
+            description = "월간 랭킹 정보를 조회합니다."
+    )
+    ApiResponse<PageResponse<RankingV1Dto.RankingResponse>> getMonthlyRanking(int page, int size, LocalDate date);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -27,4 +27,24 @@ public class RankingV1Controller implements RankingV1ApiSpec {
         PageResponse<RankingResult> result = rankingFacade.getRankProducts(new RankingCriteria.Search(page, size, today));
         return ApiResponse.success(result.map(RankingV1Dto.RankingResponse::from));
     }
+
+    @Override
+    public ApiResponse<PageResponse<RankingV1Dto.RankingResponse>> getWeeklyRanking(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) LocalDate date) {
+        date = date == null ? LocalDate.now() : date;
+        PageResponse<RankingResult> result = rankingFacade.getWeeklyRankProduct(new RankingCriteria.Search(page, size, date));
+        return ApiResponse.success(result.map(RankingV1Dto.RankingResponse::from));
+    }
+
+    @Override
+    public ApiResponse<PageResponse<RankingV1Dto.RankingResponse>> getMonthlyRanking(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) LocalDate date) {
+        date = date == null ? LocalDate.now() : date;
+        PageResponse<RankingResult> result = rankingFacade.getMonthlyRankProduct(new RankingCriteria.Search(page, size, date));
+        return ApiResponse.success(result.map(RankingV1Dto.RankingResponse::from));
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.loopers.domain.PageResponse;
 import com.loopers.key.MetricsKeys;
+import com.loopers.utils.DatabaseCleanUp;
 import com.loopers.utils.RedisCleanUp;
 import java.time.LocalDate;
 import org.junit.jupiter.api.AfterEach;
@@ -19,13 +20,18 @@ class RankingServiceIntegrationTest {
     @Autowired
     private RankingService rankingService;
     @Autowired
+    private RankingMvRepository rankingMvRepository;
+    @Autowired
     private RedisTemplate<String, String> redisTemplate;
     @Autowired
     private RedisCleanUp redisCleanUp;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
 
     @AfterEach
     void tearDown() {
         redisCleanUp.truncateAll();
+        databaseCleanUp.truncateAllTables();
     }
 
     @Nested
@@ -141,6 +147,182 @@ class RankingServiceIntegrationTest {
             assertThat(result.getTotalPages()).isEqualTo(2);
             assertThat(result.getPageNumber()).isEqualTo(1);
             assertThat(result.getPageSize()).isEqualTo(20);
+        }
+    }
+
+    @Nested
+    @DisplayName("주간 랭킹 조회 시,")
+    class WeeklyRanking {
+        @Test
+        @DisplayName("해당 페이지의 주간 랭킹 정보를 반환한다.")
+        void getWeeklyRanking() {
+            for (int i = 1; i <= 20; i++) {
+                WeeklyRankingProductMv mv = new WeeklyRankingProductMv((long) i, i, 100 - (i - 1) * 5.0, LocalDate.now());
+                rankingMvRepository.save(mv);
+            }
+
+            PageResponse<RankingInfo> infos = rankingService.getWeeklyRankings(new RankingCommand.Rankings(10, 2, LocalDate.now()));
+
+            assertThat(infos.getTotalElements()).isEqualTo(20);
+            assertThat(infos.getTotalPages()).isEqualTo(2);
+            assertThat(infos.getPageNumber()).isEqualTo(2);
+            assertThat(infos.getPageSize()).isEqualTo(10);
+            assertThat(infos.getContent().size()).isEqualTo(10);
+            assertThat(infos.getContent().get(0).productId()).isEqualTo(11L);
+            assertThat(infos.getContent().get(0).rank()).isEqualTo(11L);
+            assertThat(infos.getContent().get(9).productId()).isEqualTo(20L);
+            assertThat(infos.getContent().get(9).rank()).isEqualTo(20L);
+        }
+
+        @Test
+        @DisplayName("사이즈보다 적게 존재하는 경우, 존재하는 만큼만 반환한다.")
+        void getWeeklyRankingWithLessSize() {
+            for (int i = 1; i <= 3; i++) {
+                WeeklyRankingProductMv mv = new WeeklyRankingProductMv((long) i, i, 100 - (i - 1) * 5.0, LocalDate.now());
+                rankingMvRepository.save(mv);
+            }
+
+            PageResponse<RankingInfo> infos = rankingService.getWeeklyRankings(new RankingCommand.Rankings(10, 1, LocalDate.now()));
+
+            assertThat(infos.getTotalElements()).isEqualTo(3);
+            assertThat(infos.getTotalPages()).isEqualTo(1);
+            assertThat(infos.getPageNumber()).isEqualTo(1);
+            assertThat(infos.getPageSize()).isEqualTo(10);
+            assertThat(infos.getContent().size()).isEqualTo(3);
+            assertThat(infos.getContent().get(0).productId()).isEqualTo(1L);
+            assertThat(infos.getContent().get(0).rank()).isEqualTo(1L);
+            assertThat(infos.getContent().get(2).productId()).isEqualTo(3L);
+            assertThat(infos.getContent().get(2).rank()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("1 미만의 페이지를 요청하는 경우, 1페이지를 반환한다.")
+        void getWeeklyRanking_withPageLessThanOne() {
+            for (int i = 1; i <= 20; i++) {
+                WeeklyRankingProductMv mv = new WeeklyRankingProductMv((long) i, i, 100 - (i - 1) * 5.0, LocalDate.now());
+                rankingMvRepository.save(mv);
+            }
+
+            PageResponse<RankingInfo> infos = rankingService.getWeeklyRankings(new RankingCommand.Rankings(10, 0, LocalDate.now()));
+
+            assertThat(infos.getTotalElements()).isEqualTo(20);
+            assertThat(infos.getTotalPages()).isEqualTo(2);
+            assertThat(infos.getPageNumber()).isEqualTo(1);
+            assertThat(infos.getPageSize()).isEqualTo(10);
+            assertThat(infos.getContent().size()).isEqualTo(10);
+            assertThat(infos.getContent().get(0).productId()).isEqualTo(1L);
+            assertThat(infos.getContent().get(0).rank()).isEqualTo(1L);
+            assertThat(infos.getContent().get(9).productId()).isEqualTo(10L);
+            assertThat(infos.getContent().get(9).rank()).isEqualTo(10L);
+        }
+
+        @Test
+        @DisplayName("페이지 사이즈가 5 미만인 경우, 5로 고정하여 반환한다.")
+        void getWeeklyRanking_withSizeLessThanFive() {
+            for (int i = 1; i <= 20; i++) {
+                WeeklyRankingProductMv mv = new WeeklyRankingProductMv((long) i, i, 100 - (i - 1) * 5.0, LocalDate.now());
+                rankingMvRepository.save(mv);
+            }
+
+            PageResponse<RankingInfo> infos = rankingService.getWeeklyRankings(new RankingCommand.Rankings(3, 1, LocalDate.now()));
+
+            assertThat(infos.getTotalElements()).isEqualTo(20);
+            assertThat(infos.getTotalPages()).isEqualTo(4);
+            assertThat(infos.getPageNumber()).isEqualTo(1);
+            assertThat(infos.getPageSize()).isEqualTo(5);
+            assertThat(infos.getContent().size()).isEqualTo(5);
+            assertThat(infos.getContent().get(0).productId()).isEqualTo(1L);
+            assertThat(infos.getContent().get(0).rank()).isEqualTo(1L);
+            assertThat(infos.getContent().get(4).productId()).isEqualTo(5L);
+            assertThat(infos.getContent().get(4).rank()).isEqualTo(5L);
+        }
+    }
+
+    @Nested
+    @DisplayName("월간 랭킹 조회 시,")
+    class MonthlyRanking {
+        @Test
+        @DisplayName("해당 페이지의 월간 랭킹 정보를 반환한다.")
+        void getMonthlyRanking() {
+            for (int i = 1; i <= 20; i++) {
+                MonthlyRankingProductMv mv = new MonthlyRankingProductMv((long) i, i, 100 - (i - 1) * 5.0, LocalDate.now());
+                rankingMvRepository.save(mv);
+            }
+
+            PageResponse<RankingInfo> infos = rankingService.getMonthlyRankings(new RankingCommand.Rankings(10, 2, LocalDate.now()));
+
+            assertThat(infos.getTotalElements()).isEqualTo(20);
+            assertThat(infos.getTotalPages()).isEqualTo(2);
+            assertThat(infos.getPageNumber()).isEqualTo(2);
+            assertThat(infos.getPageSize()).isEqualTo(10);
+            assertThat(infos.getContent().size()).isEqualTo(10);
+            assertThat(infos.getContent().get(0).productId()).isEqualTo(11L);
+            assertThat(infos.getContent().get(0).rank()).isEqualTo(11L);
+            assertThat(infos.getContent().get(9).productId()).isEqualTo(20L);
+            assertThat(infos.getContent().get(9).rank()).isEqualTo(20L);
+        }
+
+        @Test
+        @DisplayName("사이즈보다 적게 존재하는 경우, 존재하는 만큼만 반환한다.")
+        void getMonthlyRanking_withLessSize() {
+            for (int i = 1; i <= 3; i++) {
+                MonthlyRankingProductMv mv = new MonthlyRankingProductMv((long) i, i, 100 - (i - 1) * 5.0, LocalDate.now());
+                rankingMvRepository.save(mv);
+            }
+
+            PageResponse<RankingInfo> infos = rankingService.getMonthlyRankings(new RankingCommand.Rankings(10, 1, LocalDate.now()));
+
+            assertThat(infos.getTotalElements()).isEqualTo(3);
+            assertThat(infos.getTotalPages()).isEqualTo(1);
+            assertThat(infos.getPageNumber()).isEqualTo(1);
+            assertThat(infos.getPageSize()).isEqualTo(10);
+            assertThat(infos.getContent().size()).isEqualTo(3);
+            assertThat(infos.getContent().get(0).productId()).isEqualTo(1L);
+            assertThat(infos.getContent().get(0).rank()).isEqualTo(1L);
+            assertThat(infos.getContent().get(2).productId()).isEqualTo(3L);
+            assertThat(infos.getContent().get(2).rank()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("1 미만의 페이지를 요청하는 경우, 1페이지를 반환한다.")
+        void getMonthlyRanking_withPageLessThanOne() {
+            for (int i = 1; i <= 20; i++) {
+                MonthlyRankingProductMv mv = new MonthlyRankingProductMv((long) i, i, 100 - (i - 1) * 5.0, LocalDate.now());
+                rankingMvRepository.save(mv);
+            }
+
+            PageResponse<RankingInfo> infos = rankingService.getMonthlyRankings(new RankingCommand.Rankings(10, 0, LocalDate.now()));
+
+            assertThat(infos.getTotalElements()).isEqualTo(20);
+            assertThat(infos.getTotalPages()).isEqualTo(2);
+            assertThat(infos.getPageNumber()).isEqualTo(1);
+            assertThat(infos.getPageSize()).isEqualTo(10);
+            assertThat(infos.getContent().size()).isEqualTo(10);
+            assertThat(infos.getContent().get(0).productId()).isEqualTo(1L);
+            assertThat(infos.getContent().get(0).rank()).isEqualTo(1L);
+            assertThat(infos.getContent().get(9).productId()).isEqualTo(10L);
+            assertThat(infos.getContent().get(9).rank()).isEqualTo(10L);
+        }
+
+        @Test
+        @DisplayName("페이지 사이즈가 5 미만인 경우, 5로 고정하여 반환한다.")
+        void getMonthlyRanking_withSizeLessThanFive() {
+            for (int i = 1; i <= 20; i++) {
+                MonthlyRankingProductMv mv = new MonthlyRankingProductMv((long) i, i, 100 - (i - 1) * 5.0, LocalDate.now());
+                rankingMvRepository.save(mv);
+            }
+
+            PageResponse<RankingInfo> infos = rankingService.getMonthlyRankings(new RankingCommand.Rankings(3, 1, LocalDate.now()));
+
+            assertThat(infos.getTotalElements()).isEqualTo(20);
+            assertThat(infos.getTotalPages()).isEqualTo(4);
+            assertThat(infos.getPageNumber()).isEqualTo(1);
+            assertThat(infos.getPageSize()).isEqualTo(5);
+            assertThat(infos.getContent().size()).isEqualTo(5);
+            assertThat(infos.getContent().get(0).productId()).isEqualTo(1L);
+            assertThat(infos.getContent().get(0).rank()).isEqualTo(1L);
+            assertThat(infos.getContent().get(4).productId()).isEqualTo(5L);
+            assertThat(infos.getContent().get(4).rank()).isEqualTo(5L);
         }
     }
 

--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -1,0 +1,26 @@
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
+
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+
+    // querydsl
+    implementation("com.querydsl:querydsl-jpa::jakarta")
+
+    implementation("io.github.resilience4j:resilience4j-spring-boot3")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+    testImplementation("org.springframework.batch:spring-batch-test")
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
@@ -1,0 +1,24 @@
+package com.loopers;
+
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@ConfigurationPropertiesScan
+@SpringBootApplication
+@EnableScheduling
+public class CommerceBatchApplication {
+
+    @PostConstruct
+    public void started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(CommerceBatchApplication.class, args);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingProcessor.java
@@ -1,0 +1,23 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.MonthlyRankingScore;
+import com.loopers.domain.ranking.MonthlyWeight;
+import com.loopers.domain.ranking.WeeklyProductRankMv;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import org.springframework.batch.item.ItemProcessor;
+
+public class MonthlyRankingProcessor implements ItemProcessor<WeeklyProductRankMv, MonthlyRankingScore> {
+    private final LocalDate date;
+
+    public MonthlyRankingProcessor(String dateStr) {
+        this.date = LocalDate.parse(dateStr);
+    }
+
+    @Override
+    public MonthlyRankingScore process(WeeklyProductRankMv item) throws Exception {
+        int weeksDiff = (int) ChronoUnit.WEEKS.between(date, item.getDate());
+        MonthlyWeight monthlyWeight = MonthlyWeight.fromWeeksDiff(weeksDiff);
+        return new MonthlyRankingScore(item.getProductId(), monthlyWeight.applyWeight(item.getScore()));
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingProcessor.java
@@ -16,8 +16,8 @@ public class MonthlyRankingProcessor implements ItemProcessor<WeeklyProductRankM
 
     @Override
     public MonthlyRankingScore process(WeeklyProductRankMv item) throws Exception {
-        int weeksDiff = (int) ChronoUnit.WEEKS.between(date, item.getDate());
+        int weeksDiff = (int) ChronoUnit.WEEKS.between(item.getDate(), date);
         MonthlyWeight monthlyWeight = MonthlyWeight.fromWeeksDiff(weeksDiff);
-        return new MonthlyRankingScore(item.getProductId(), monthlyWeight.applyWeight(item.getScore()));
+        return new MonthlyRankingScore(item.getProductId(), item.getScore(), monthlyWeight.applyWeight(item.getScore()));
     }
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingReader.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingReader.java
@@ -1,0 +1,29 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.WeeklyProductRankMv;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+
+public class MonthlyRankingReader extends JpaPagingItemReader<WeeklyProductRankMv> {
+
+    public MonthlyRankingReader(EntityManagerFactory emf,
+                                String dateStr) {
+        setEntityManagerFactory(emf);
+        setQueryString("SELECT w "
+                + "FROM WeeklyProductRankMv w "
+                + "WHERE w.date IN (:d0, :d1, :d2, :d3)"
+        );
+        LocalDate date = LocalDate.parse(dateStr);
+        Map<String, Object> params = new HashMap<>();
+        params.put("d0", date);
+        params.put("d1", date.minusWeeks(1));
+        params.put("d2", date.minusWeeks(2));
+        params.put("d3", date.minusWeeks(3));
+        setParameterValues(params);
+        setEntityManagerFactory(emf);
+        setPageSize(300);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingStepListener.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingStepListener.java
@@ -21,7 +21,7 @@ public class MonthlyRankingStepListener implements StepExecutionListener {
         LocalDate date = LocalDate.parse(dateStr);
 
         List<MonthlyProductRankMv> mvs = rankingBuffer.getMonthlyRankings(300).stream()
-                .map(info -> new MonthlyProductRankMv(info.productId(), info.score(), info.rank(), date.plusDays(1)))
+                .map(r -> new MonthlyProductRankMv(r.productId(), r.score(), r.weightedScore(), r.rank(), date.plusDays(1)))
                 .toList();
 
         rankMvRepository.saveMonthlyRankingMvs(mvs);

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingStepListener.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingStepListener.java
@@ -1,0 +1,32 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.MonthlyProductRankMv;
+import com.loopers.domain.ranking.RankMvRepository;
+import com.loopers.domain.ranking.RankingBuffer;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+
+@RequiredArgsConstructor
+public class MonthlyRankingStepListener implements StepExecutionListener {
+    private final RankingBuffer rankingBuffer;
+    private final RankMvRepository rankMvRepository;
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        String dateStr = stepExecution.getJobParameters().getString("date");
+        LocalDate date = LocalDate.parse(dateStr);
+
+        List<MonthlyProductRankMv> mvs = rankingBuffer.getMonthlyRankings(300).stream()
+                .map(info -> new MonthlyProductRankMv(info.productId(), info.score(), info.rank(), date.plusDays(1)))
+                .toList();
+
+        rankMvRepository.saveMonthlyRankingMvs(mvs);
+        rankingBuffer.clearMonthlyBuffer();
+
+        return ExitStatus.COMPLETED;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingWriter.java
@@ -1,0 +1,19 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.MonthlyRankingScore;
+import com.loopers.domain.ranking.RankingBuffer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+
+@RequiredArgsConstructor
+public class MonthlyRankingWriter implements ItemWriter<MonthlyRankingScore> {
+    private final RankingBuffer rankingBuffer;
+
+    @Override
+    public void write(Chunk<? extends MonthlyRankingScore> chunk) throws Exception {
+        for (MonthlyRankingScore item : chunk) {
+            rankingBuffer.record(item);
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingWriter.java
@@ -13,7 +13,7 @@ public class MonthlyRankingWriter implements ItemWriter<MonthlyRankingScore> {
     @Override
     public void write(Chunk<? extends MonthlyRankingScore> chunk) throws Exception {
         for (MonthlyRankingScore item : chunk) {
-            rankingBuffer.record(item);
+            rankingBuffer.recordMonthly(item);
         }
     }
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/RankingStepConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/RankingStepConfig.java
@@ -1,0 +1,104 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.DailyMetric;
+import com.loopers.domain.ranking.MonthlyRankingScore;
+import com.loopers.domain.ranking.RankMvRepository;
+import com.loopers.domain.ranking.RankingBuffer;
+import com.loopers.domain.ranking.WeeklyProductRankMv;
+import com.loopers.domain.ranking.WeeklyRankingScore;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class RankingStepConfig {
+    @Bean
+    public Step weeklyRankingStep(JobRepository jobRepository,
+                                  PlatformTransactionManager tm,
+                                  WeeklyRankingReader reader,
+                                  WeeklyRankingProcessor processor,
+                                  WeeklyRankingWriter writer,
+                                  WeeklyRankingStepListener listener) {
+        return new StepBuilder("weeklyRankingStep", jobRepository)
+                .<DailyMetric, WeeklyRankingScore>chunk(500, tm)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .listener(listener)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public WeeklyRankingReader weeklyRankingReader(EntityManagerFactory emf,
+                                                   @Value("#{jobParameters['date']}") String dateStr) {
+        return new WeeklyRankingReader(emf, dateStr);
+    }
+
+    @Bean
+    @StepScope
+    public WeeklyRankingProcessor weeklyRankingProcessor(@Value("#{jobParameters['date']}") String dateStr) {
+        return new WeeklyRankingProcessor(dateStr);
+    }
+
+    @Bean
+    @StepScope
+    public WeeklyRankingWriter weeklyRankingWriter(RankingBuffer rankingBuffer) {
+        return new WeeklyRankingWriter(rankingBuffer);
+    }
+
+    @Bean
+    @StepScope
+    public WeeklyRankingStepListener weeklyRankingStepListener(RankingBuffer rankingBuffer, RankMvRepository rankMvRepository) {
+        return new WeeklyRankingStepListener(rankingBuffer, rankMvRepository);
+    }
+
+    @Bean
+    public Step monthlyRankingStep(JobRepository jobRepository,
+                                   PlatformTransactionManager tm,
+                                   MonthlyRankingReader reader,
+                                   MonthlyRankingProcessor processor,
+                                   MonthlyRankingWriter writer,
+                                   MonthlyRankingStepListener listener) {
+        return new StepBuilder("monthlyRankingStep", jobRepository)
+                .<WeeklyProductRankMv, MonthlyRankingScore>chunk(500, tm)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .listener(listener)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public MonthlyRankingReader monthlyRankingReader(EntityManagerFactory emf,
+                                                     @Value("#{jobParameters['date']}") String dateStr) {
+        return new MonthlyRankingReader(emf, dateStr);
+    }
+
+    @Bean
+    @StepScope
+    public MonthlyRankingProcessor monthlyRankingProcessor(@Value("#{jobParameters['date']}") String dateStr) {
+        return new MonthlyRankingProcessor(dateStr);
+    }
+
+    @Bean
+    @StepScope
+    public MonthlyRankingWriter monthlyRankingWriter(RankingBuffer rankingBuffer) {
+        return new MonthlyRankingWriter(rankingBuffer);
+    }
+
+    @Bean
+    @StepScope
+    public MonthlyRankingStepListener monthlyRankingStepListener(RankingBuffer rankingBuffer, RankMvRepository rankMvRepository) {
+        return new MonthlyRankingStepListener(rankingBuffer, rankMvRepository);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingProcessor.java
@@ -1,0 +1,22 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.DailyMetric;
+import com.loopers.domain.ranking.WeeklyRankingScore;
+import com.loopers.domain.ranking.WeeklyWeight;
+import java.time.LocalDate;
+import org.springframework.batch.item.ItemProcessor;
+
+public class WeeklyRankingProcessor implements ItemProcessor<DailyMetric, WeeklyRankingScore> {
+    private final LocalDate date;
+
+    public WeeklyRankingProcessor(String date) {
+        this.date = LocalDate.parse(date);
+    }
+
+    @Override
+    public WeeklyRankingScore process(DailyMetric item) {
+        int daysDiff = (int) (date.toEpochDay() - item.getDate().toEpochDay());
+        WeeklyWeight weeklyWeight = WeeklyWeight.fromDaysDiff(daysDiff);
+        return new WeeklyRankingScore(item.getProductId(), weeklyWeight.applyWeight(item.calculateScore()));
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingProcessor.java
@@ -17,6 +17,6 @@ public class WeeklyRankingProcessor implements ItemProcessor<DailyMetric, Weekly
     public WeeklyRankingScore process(DailyMetric item) {
         int daysDiff = (int) (date.toEpochDay() - item.getDate().toEpochDay());
         WeeklyWeight weeklyWeight = WeeklyWeight.fromDaysDiff(daysDiff);
-        return new WeeklyRankingScore(item.getProductId(), weeklyWeight.applyWeight(item.calculateScore()));
+        return new WeeklyRankingScore(item.getProductId(), item.calculateScore(), weeklyWeight.applyWeight(item.calculateScore()));
     }
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingReader.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingReader.java
@@ -1,0 +1,22 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.DailyMetric;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.LocalDate;
+import java.util.Map;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+
+public class WeeklyRankingReader extends JpaPagingItemReader<DailyMetric> {
+
+    public WeeklyRankingReader(EntityManagerFactory emf,
+                               String date) {
+        setEntityManagerFactory(emf);
+        setQueryString(
+                "SELECT d " +
+                        "FROM DailyMetric d " +
+                        "WHERE d.date >= :startDate"
+        );
+        setParameterValues(Map.of("startDate", LocalDate.parse(date).minusDays(6)));
+        setPageSize(500);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingStepListener.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingStepListener.java
@@ -1,0 +1,32 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.RankMvRepository;
+import com.loopers.domain.ranking.RankingBuffer;
+import com.loopers.domain.ranking.WeeklyProductRankMv;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+
+@RequiredArgsConstructor
+public class WeeklyRankingStepListener implements StepExecutionListener {
+    private final RankingBuffer rankingBuffer;
+    private final RankMvRepository rankMvRepository;
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        String dateStr = stepExecution.getJobParameters().getString("date");
+        LocalDate date = LocalDate.parse(dateStr);
+
+        List<WeeklyProductRankMv> mvs = rankingBuffer.getWeeklyRankings(300).stream()
+                .map(r -> new WeeklyProductRankMv(r.productId(), r.rank(), r.score(), date.plusDays(1)))
+                .toList();
+
+        rankMvRepository.saveWeeklyRankingMvs(mvs);
+        rankingBuffer.clearWeeklyBuffer();
+
+        return ExitStatus.COMPLETED;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingStepListener.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingStepListener.java
@@ -21,7 +21,7 @@ public class WeeklyRankingStepListener implements StepExecutionListener {
         LocalDate date = LocalDate.parse(dateStr);
 
         List<WeeklyProductRankMv> mvs = rankingBuffer.getWeeklyRankings(300).stream()
-                .map(r -> new WeeklyProductRankMv(r.productId(), r.rank(), r.score(), date.plusDays(1)))
+                .map(r -> new WeeklyProductRankMv(r.productId(), r.rank(), r.score(), r.weightedScore(), date.plusDays(1)))
                 .toList();
 
         rankMvRepository.saveWeeklyRankingMvs(mvs);

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingWriter.java
@@ -1,0 +1,19 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.RankingBuffer;
+import com.loopers.domain.ranking.WeeklyRankingScore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+
+@RequiredArgsConstructor
+public class WeeklyRankingWriter implements ItemWriter<WeeklyRankingScore> {
+    private final RankingBuffer rankingBuffer;
+
+    @Override
+    public void write(Chunk<? extends WeeklyRankingScore> chunk) throws Exception {
+        for (WeeklyRankingScore weeklyRankingScore : chunk) {
+            rankingBuffer.recordWeekly(weeklyRankingScore);
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/RankingJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/RankingJobConfig.java
@@ -1,0 +1,22 @@
+package com.loopers.batch.job;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RankingJobConfig {
+
+    @Bean
+    public Job rankingJob(JobRepository jobRepository,
+                          Step weeklyRankingStep,
+                          Step monthlyRankingStep) {
+        return new JobBuilder("rankingJob", jobRepository)
+                .start(weeklyRankingStep)
+                .next(monthlyRankingStep)
+                .build();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/DailyMetric.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/DailyMetric.java
@@ -46,6 +46,6 @@ public class DailyMetric {
     }
 
     public Double calculateScore() {
-        return likeCount * 0.2 + salesCount * 1.0 + viewCount * 0.1;
+        return likeCount * 0.2 + salesCount * 0.7 + viewCount * 0.1;
     }
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/DailyMetric.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/DailyMetric.java
@@ -1,0 +1,51 @@
+package com.loopers.domain.ranking;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "product_metrics")
+public class DailyMetric {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "ref_product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "like_count", nullable = false)
+    private Long likeCount;
+
+    @Column(name = "sales_count", nullable = false)
+    private Long salesCount;
+
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    protected DailyMetric() {
+    }
+
+    public DailyMetric(Long productId, Long likeCount, Long salesCount, Long viewCount, LocalDate date) {
+        this.productId = productId;
+        this.likeCount = likeCount;
+        this.salesCount = salesCount;
+        this.viewCount = viewCount;
+        this.date = date;
+    }
+
+    public Double calculateScore() {
+        return likeCount * 0.2 + salesCount * 1.0 + viewCount * 0.1;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyProductRankMv.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyProductRankMv.java
@@ -1,0 +1,42 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "mv_product_rank_monthly")
+public class MonthlyProductRankMv {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @Column(name = "ref_product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "monthly_rank", nullable = false)
+    private Integer rank;
+
+    @Column(name = "score", nullable = false)
+    private Double score;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    protected MonthlyProductRankMv() {
+    }
+
+    public MonthlyProductRankMv(Long productId, Double score, Integer rank, LocalDate date) {
+        this.productId = productId;
+        this.score = score;
+        this.rank = rank;
+        this.date = date;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyProductRankMv.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyProductRankMv.java
@@ -6,17 +6,19 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
 import lombok.Getter;
 
 @Entity
 @Getter
-@Table(name = "mv_product_rank_monthly")
+@Table(name = "mv_product_rank_monthly",uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"ref_product_id", "date"})
+})
 public class MonthlyProductRankMv {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
 
     @Column(name = "ref_product_id", nullable = false)
     private Long productId;

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyProductRankMv.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyProductRankMv.java
@@ -27,15 +27,19 @@ public class MonthlyProductRankMv {
     @Column(name = "score", nullable = false)
     private Double score;
 
+    @Column(name = "weighted_score", nullable = false)
+    private Double weightedScore;
+
     @Column(name = "date", nullable = false)
     private LocalDate date;
 
     protected MonthlyProductRankMv() {
     }
 
-    public MonthlyProductRankMv(Long productId, Double score, Integer rank, LocalDate date) {
+    public MonthlyProductRankMv(Long productId, Double score, Double weightedScore, Integer rank, LocalDate date) {
         this.productId = productId;
         this.score = score;
+        this.weightedScore = weightedScore;
         this.rank = rank;
         this.date = date;
     }

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingScore.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingScore.java
@@ -2,6 +2,7 @@ package com.loopers.domain.ranking;
 
 public record MonthlyRankingScore(
         Long productId,
-        Double score
+        Double score,
+        Double weightedScore
 ) {
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingScore.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingScore.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.ranking;
+
+public record MonthlyRankingScore(
+        Long productId,
+        Double score
+) {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyWeight.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyWeight.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.ranking;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum MonthlyWeight {
+    WEEK_0(1.0),
+    WEEK_1(0.8),
+    WEEK_2(0.5),
+    WEEK_3(0.2),
+    OTHER(0.0);
+
+    private final double weight;
+
+    public double applyWeight(double score) {
+        return score * weight;
+    }
+
+    public static MonthlyWeight fromWeeksDiff(int weeksDiff) {
+        return switch (weeksDiff) {
+            case 0 -> WEEK_0;
+            case 1 -> WEEK_1;
+            case 2 -> WEEK_2;
+            case 3 -> WEEK_3;
+            default -> OTHER;
+        };
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankMvRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankMvRepository.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface RankMvRepository {
+    void saveWeeklyRankingMvs(Iterable<WeeklyProductRankMv> entities);
+
+    void saveMonthlyRankingMvs(Iterable<MonthlyProductRankMv> entities);
+
+    List<WeeklyProductRankMv> findWeeklyRankMv(LocalDate date);
+
+    List<MonthlyProductRankMv> findMonthlyRankMv(LocalDate date);
+
+    Optional<MonthlyProductRankMv> findMonthlyRankMvByProductId(LocalDate date, Long productId);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingBoardInfo.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingBoardInfo.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.ranking;
+
+public record RankingBoardInfo(
+        Long productId,
+        Double score,
+        Integer rank
+) {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingBoardInfo.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingBoardInfo.java
@@ -3,6 +3,7 @@ package com.loopers.domain.ranking;
 public record RankingBoardInfo(
         Long productId,
         Double score,
+        Double weightedScore,
         Integer rank
 ) {
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingBuffer.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingBuffer.java
@@ -7,7 +7,7 @@ public interface RankingBuffer {
 
     List<RankingBoardInfo> getWeeklyRankings(int limit);
 
-    void record(MonthlyRankingScore score);
+    void recordMonthly(MonthlyRankingScore score);
 
     List<RankingBoardInfo> getMonthlyRankings(int limit);
 

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingBuffer.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingBuffer.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.ranking;
+
+import java.util.List;
+
+public interface RankingBuffer {
+    void recordWeekly(WeeklyRankingScore metric);
+
+    List<RankingBoardInfo> getWeeklyRankings(int limit);
+
+    void record(MonthlyRankingScore score);
+
+    List<RankingBoardInfo> getMonthlyRankings(int limit);
+
+    void clearMonthlyBuffer();
+
+    void clearWeeklyBuffer();
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyProductRankMv.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyProductRankMv.java
@@ -1,0 +1,41 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "mv_product_rank_weekly")
+public class WeeklyProductRankMv {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "ref_product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "weekly_rank", nullable = false)
+    private Integer rank;
+
+    @Column(name = "score", nullable = false)
+    private Double score;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    protected WeeklyProductRankMv() {
+    }
+
+    public WeeklyProductRankMv(Long productId, Integer rank, Double score, LocalDate date) {
+        this.productId = productId;
+        this.rank = rank;
+        this.score = score;
+        this.date = date;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyProductRankMv.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyProductRankMv.java
@@ -26,16 +26,20 @@ public class WeeklyProductRankMv {
     @Column(name = "score", nullable = false)
     private Double score;
 
+    @Column(name = "weighted_score", nullable = false)
+    private Double weightedScore;
+
     @Column(name = "date", nullable = false)
     private LocalDate date;
 
     protected WeeklyProductRankMv() {
     }
 
-    public WeeklyProductRankMv(Long productId, Integer rank, Double score, LocalDate date) {
+    public WeeklyProductRankMv(Long productId, Integer rank, Double score, Double weightedScore, LocalDate date) {
         this.productId = productId;
         this.rank = rank;
         this.score = score;
+        this.weightedScore = weightedScore;
         this.date = date;
     }
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyProductRankMv.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyProductRankMv.java
@@ -6,12 +6,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
 import lombok.Getter;
 
 @Entity
 @Getter
-@Table(name = "mv_product_rank_weekly")
+@Table(name = "mv_product_rank_weekly", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"ref_product_id", "date"})
+})
 public class WeeklyProductRankMv {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingScore.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingScore.java
@@ -2,6 +2,7 @@ package com.loopers.domain.ranking;
 
 public record WeeklyRankingScore(
         Long productId,
-        Double score
+        Double score,
+        Double weightedScore
 ) {
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingScore.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingScore.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.ranking;
+
+public record WeeklyRankingScore(
+        Long productId,
+        Double score
+) {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyWeight.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyWeight.java
@@ -1,0 +1,34 @@
+package com.loopers.domain.ranking;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum WeeklyWeight {
+    DAY_0(1.0),
+    DAY_1(0.9),
+    DAY_2(0.8),
+    DAY_3(0.7),
+    DAY_4(0.4),
+    DAY_5(0.2),
+    DAY_6(0.1),
+    OTHER(0.0);
+
+    private final double weight;
+
+    public double applyWeight(double score) {
+        return score * weight;
+    }
+
+    public static WeeklyWeight fromDaysDiff(int daysDiff) {
+        return switch (daysDiff) {
+            case 0 -> DAY_0;
+            case 1 -> DAY_1;
+            case 2 -> DAY_2;
+            case 3 -> DAY_3;
+            case 4 -> DAY_4;
+            case 5 -> DAY_5;
+            case 6 -> DAY_6;
+            default -> OTHER;
+        };
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/DailyMetricJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/DailyMetricJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.DailyMetric;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyMetricJpaRepository extends JpaRepository<DailyMetric, Long> {
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyProductRankMvJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyProductRankMvJpaRepository.java
@@ -1,0 +1,13 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MonthlyProductRankMv;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MonthlyProductRankMvJpaRepository extends JpaRepository<MonthlyProductRankMv, Long> {
+    List<MonthlyProductRankMv> findByDate(LocalDate date);
+
+    Optional<MonthlyProductRankMv> findByDateAndProductId(LocalDate date, Long productId);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/RankMvRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/RankMvRepositoryImpl.java
@@ -20,8 +20,16 @@ public class RankMvRepositoryImpl implements RankMvRepository {
 
     @Override
     public void saveWeeklyRankingMvs(Iterable<WeeklyProductRankMv> entities) {
-        String sql = "INSERT INTO mv_product_rank_weekly (ref_product_id, weekly_rank, score, weighted_score, date) VALUES (?, ?, ?, ?, ?)";
+        String sql = "INSERT INTO mv_product_rank_weekly (ref_product_id, weekly_rank, score, weighted_score, date) " +
+                "VALUES (?, ?, ?, ?, ?) " +
+                "ON DUPLICATE KEY UPDATE " +
+                "weekly_rank = VALUES(weekly_rank), " +
+                "score = VALUES(score), " +
+                "weighted_score = VALUES(weighted_score), " +
+                "date = VALUES(date)";
+
         List<Object[]> batchArgs = new ArrayList<>();
+
         for (WeeklyProductRankMv entity : entities) {
             batchArgs.add(new Object[]{
                     entity.getProductId(),
@@ -32,12 +40,21 @@ public class RankMvRepositoryImpl implements RankMvRepository {
             });
         }
         jdbcTemplate.batchUpdate(sql, batchArgs);
+
     }
 
     @Override
     public void saveMonthlyRankingMvs(Iterable<MonthlyProductRankMv> entities) {
-        String sql = "INSERT INTO mv_product_rank_monthly (ref_product_id, monthly_rank, score, weighted_score, date) VALUES (?, ?, ?, ?, ?)";
+        String sql = "INSERT INTO mv_product_rank_monthly (ref_product_id, monthly_rank, score, weighted_score, date) " +
+                "VALUES (?, ?, ?, ?, ?) " +
+                "ON DUPLICATE KEY UPDATE " +
+                "monthly_rank = VALUES(monthly_rank), " +
+                "score = VALUES(score), " +
+                "weighted_score = VALUES(weighted_score), " +
+                "date = VALUES(date)";
+      
         List<Object[]> batchArgs = new ArrayList<>();
+
         for (MonthlyProductRankMv entity : entities) {
             batchArgs.add(new Object[]{
                     entity.getProductId(),

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/RankMvRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/RankMvRepositoryImpl.java
@@ -20,13 +20,14 @@ public class RankMvRepositoryImpl implements RankMvRepository {
 
     @Override
     public void saveWeeklyRankingMvs(Iterable<WeeklyProductRankMv> entities) {
-        String sql = "INSERT INTO mv_product_rank_weekly (ref_product_id, weekly_rank, score, date) VALUES (?, ?, ?, ?)";
+        String sql = "INSERT INTO mv_product_rank_weekly (ref_product_id, weekly_rank, score, weighted_score, date) VALUES (?, ?, ?, ?, ?)";
         List<Object[]> batchArgs = new ArrayList<>();
         for (WeeklyProductRankMv entity : entities) {
             batchArgs.add(new Object[]{
                     entity.getProductId(),
                     entity.getRank(),
                     entity.getScore(),
+                    entity.getWeightedScore(),
                     entity.getDate()
             });
         }
@@ -35,13 +36,14 @@ public class RankMvRepositoryImpl implements RankMvRepository {
 
     @Override
     public void saveMonthlyRankingMvs(Iterable<MonthlyProductRankMv> entities) {
-        String sql = "INSERT INTO mv_product_rank_monthly (ref_product_id, monthly_rank, score, date) VALUES (?, ?, ?, ?)";
+        String sql = "INSERT INTO mv_product_rank_monthly (ref_product_id, monthly_rank, score, weighted_score, date) VALUES (?, ?, ?, ?, ?)";
         List<Object[]> batchArgs = new ArrayList<>();
         for (MonthlyProductRankMv entity : entities) {
             batchArgs.add(new Object[]{
                     entity.getProductId(),
                     entity.getRank(),
                     entity.getScore(),
+                    entity.getWeightedScore(),
                     entity.getDate()
             });
         }

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/RankMvRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/RankMvRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MonthlyProductRankMv;
+import com.loopers.domain.ranking.RankMvRepository;
+import com.loopers.domain.ranking.WeeklyProductRankMv;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RankMvRepositoryImpl implements RankMvRepository {
+    private final WeeklyProductRankMvJpaRepository weeklyJpaRepository;
+    private final MonthlyProductRankMvJpaRepository monthlyJpaRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void saveWeeklyRankingMvs(Iterable<WeeklyProductRankMv> entities) {
+        String sql = "INSERT INTO mv_product_rank_weekly (ref_product_id, weekly_rank, score, date) VALUES (?, ?, ?, ?)";
+        List<Object[]> batchArgs = new ArrayList<>();
+        for (WeeklyProductRankMv entity : entities) {
+            batchArgs.add(new Object[]{
+                    entity.getProductId(),
+                    entity.getRank(),
+                    entity.getScore(),
+                    entity.getDate()
+            });
+        }
+        jdbcTemplate.batchUpdate(sql, batchArgs);
+    }
+
+    @Override
+    public void saveMonthlyRankingMvs(Iterable<MonthlyProductRankMv> entities) {
+        String sql = "INSERT INTO mv_product_rank_monthly (ref_product_id, monthly_rank, score, date) VALUES (?, ?, ?, ?)";
+        List<Object[]> batchArgs = new ArrayList<>();
+        for (MonthlyProductRankMv entity : entities) {
+            batchArgs.add(new Object[]{
+                    entity.getProductId(),
+                    entity.getRank(),
+                    entity.getScore(),
+                    entity.getDate()
+            });
+        }
+        jdbcTemplate.batchUpdate(sql, batchArgs);
+    }
+
+    @Override
+    public List<WeeklyProductRankMv> findWeeklyRankMv(LocalDate date) {
+        return weeklyJpaRepository.findWeeklyRankMvs(date);
+    }
+
+    @Override
+    public List<MonthlyProductRankMv> findMonthlyRankMv(LocalDate date) {
+        return monthlyJpaRepository.findByDate(date);
+    }
+
+    @Override
+    public Optional<MonthlyProductRankMv> findMonthlyRankMvByProductId(LocalDate date, Long productId) {
+        return monthlyJpaRepository.findByDateAndProductId(date, productId);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/RedisRankingBuffer.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/RedisRankingBuffer.java
@@ -1,0 +1,74 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MonthlyRankingScore;
+import com.loopers.domain.ranking.RankingBuffer;
+import com.loopers.domain.ranking.RankingBoardInfo;
+import com.loopers.domain.ranking.WeeklyRankingScore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisRankingBuffer implements RankingBuffer {
+    public static final String WEEKLY_BUFFER_KEY = "weekly_ranking";
+    public static final String MONTHLY_BUFFER_KEY = "monthly_ranking";
+    private final RedisTemplate<String, String> materRedisTemplate;
+    private final RedisTemplate<String, String> defaultRedisTemplate;
+
+    @Override
+    public void recordWeekly(WeeklyRankingScore metric) {
+        materRedisTemplate.opsForZSet().incrementScore(WEEKLY_BUFFER_KEY, metric.productId().toString(), metric.score());
+    }
+
+    @Override
+    public List<RankingBoardInfo> getWeeklyRankings(int limit) {
+        Set<TypedTuple<String>> weeklyRanking = defaultRedisTemplate.opsForZSet()
+                .reverseRangeWithScores(WEEKLY_BUFFER_KEY, 0, limit - 1);
+
+        int rank = 1;
+        List<RankingBoardInfo> rankingBoardInfos = new ArrayList<>();
+
+        for (TypedTuple<String> tuple : weeklyRanking) {
+            Long productId = Long.parseLong(tuple.getValue());
+            Double score = tuple.getScore();
+            rankingBoardInfos.add(new RankingBoardInfo(productId, score, rank++));
+        }
+        return rankingBoardInfos;
+    }
+
+    @Override
+    public void record(MonthlyRankingScore score) {
+        materRedisTemplate.opsForZSet().incrementScore(MONTHLY_BUFFER_KEY, score.productId().toString(), score.score());
+    }
+
+    @Override
+    public List<RankingBoardInfo> getMonthlyRankings(int limit) {
+        Set<TypedTuple<String>> monthlyRanking = defaultRedisTemplate.opsForZSet()
+                .reverseRangeWithScores(MONTHLY_BUFFER_KEY, 0, limit - 1);
+
+        int rank = 1;
+        List<RankingBoardInfo> rankingBoardInfos = new ArrayList<>();
+
+        for (TypedTuple<String> tuple : monthlyRanking) {
+            Long productId = Long.parseLong(tuple.getValue());
+            Double score = tuple.getScore();
+            rankingBoardInfos.add(new RankingBoardInfo(productId, score, rank++));
+        }
+        return rankingBoardInfos;
+    }
+
+    @Override
+    public void clearMonthlyBuffer() {
+        materRedisTemplate.delete(MONTHLY_BUFFER_KEY);
+    }
+
+    @Override
+    public void clearWeeklyBuffer() {
+        materRedisTemplate.delete(WEEKLY_BUFFER_KEY);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyProductRankMvJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyProductRankMvJpaRepository.java
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.WeeklyProductRankMv;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface WeeklyProductRankMvJpaRepository extends JpaRepository<WeeklyProductRankMv, Long> {
+    @Query("SELECT w FROM WeeklyProductRankMv w WHERE w.date = :date ORDER BY w.rank ASC")
+    List<WeeklyProductRankMv> findWeeklyRankMvs(LocalDate date);
+
+    Optional<WeeklyProductRankMv> findByProductIdAndDate(Long productId, LocalDate date);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -1,0 +1,139 @@
+package com.loopers.interfaces.api;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ServerWebInputException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@RestControllerAdvice
+@Slf4j
+public class ApiControllerAdvice {
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handle(CoreException e) {
+        log.warn("CoreException : {}", e.getCustomMessage() != null ? e.getCustomMessage() : e.getMessage(), e);
+        return failureResponse(e.getErrorType(), e.getCustomMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MethodArgumentTypeMismatchException e) {
+        String name = e.getName();
+        String type = e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown";
+        String value = e.getValue() != null ? e.getValue().toString() : "null";
+        String message = String.format("요청 파라미터 '%s' (타입: %s)의 값 '%s'이(가) 잘못되었습니다.", name, type, value);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MethodArgumentNotValidException e) {
+        return failureResponse(ErrorType.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MissingServletRequestParameterException e) {
+        String name = e.getParameterName();
+        String type = e.getParameterType();
+        String message = String.format("필수 요청 파라미터 '%s' (타입: %s)가 누락되었습니다.", name, type);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MissingRequestHeaderException e) {
+        String name = e.getHeaderName();
+        String message = String.format("필수 요청 헤더 '%s'가 누락되었습니다.", name);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(HttpMessageNotReadableException e) {
+        String errorMessage;
+        Throwable rootCause = e.getRootCause();
+
+        if (rootCause instanceof InvalidFormatException invalidFormat) {
+            String fieldName = invalidFormat.getPath().stream()
+                    .map(ref -> ref.getFieldName() != null ? ref.getFieldName() : "?")
+                    .collect(Collectors.joining("."));
+
+            String valueIndicationMessage = "";
+            if (invalidFormat.getTargetType().isEnum()) {
+                Class<?> enumClass = invalidFormat.getTargetType();
+                String enumValues = Arrays.stream(enumClass.getEnumConstants())
+                        .map(Object::toString)
+                        .collect(Collectors.joining(", "));
+                valueIndicationMessage = "사용 가능한 값 : [" + enumValues + "]";
+            }
+
+            String expectedType = invalidFormat.getTargetType().getSimpleName();
+            Object value = invalidFormat.getValue();
+
+            errorMessage = String.format("필드 '%s'의 값 '%s'이(가) 예상 타입(%s)과 일치하지 않습니다. %s",
+                    fieldName, value, expectedType, valueIndicationMessage);
+
+        } else if (rootCause instanceof MismatchedInputException mismatchedInput) {
+            String fieldPath = mismatchedInput.getPath().stream()
+                    .map(ref -> ref.getFieldName() != null ? ref.getFieldName() : "?")
+                    .collect(Collectors.joining("."));
+            errorMessage = String.format("필수 필드 '%s'이(가) 누락되었습니다.", fieldPath);
+
+        } else if (rootCause instanceof JsonMappingException jsonMapping) {
+            String fieldPath = jsonMapping.getPath().stream()
+                    .map(ref -> ref.getFieldName() != null ? ref.getFieldName() : "?")
+                    .collect(Collectors.joining("."));
+            errorMessage = String.format("필드 '%s'에서 JSON 매핑 오류가 발생했습니다: %s",
+                    fieldPath, jsonMapping.getOriginalMessage());
+
+        } else {
+            errorMessage = "요청 본문을 처리하는 중 오류가 발생했습니다. JSON 메세지 규격을 확인해주세요.";
+        }
+
+        return failureResponse(ErrorType.BAD_REQUEST, errorMessage);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(ServerWebInputException e) {
+        String missingParams = extractMissingParameter(e.getReason() != null ? e.getReason() : "");
+        if (!missingParams.isEmpty()) {
+            String message = String.format("필수 요청 값 '%s'가 누락되었습니다.", missingParams);
+            return failureResponse(ErrorType.BAD_REQUEST, message);
+        } else {
+            return failureResponse(ErrorType.BAD_REQUEST, null);
+        }
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleNotFound(NoResourceFoundException e) {
+        return failureResponse(ErrorType.NOT_FOUND, null);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handle(Throwable e) {
+        log.error("Exception : {}", e.getMessage(), e);
+        return failureResponse(ErrorType.INTERNAL_ERROR, null);
+    }
+
+    private String extractMissingParameter(String message) {
+        Pattern pattern = Pattern.compile("'(.+?)'");
+        Matcher matcher = pattern.matcher(message);
+        return matcher.find() ? matcher.group(1) : "";
+    }
+
+    private ResponseEntity<ApiResponse<?>> failureResponse(ErrorType errorType, String errorMessage) {
+        return ResponseEntity.status(errorType.getStatus())
+                .body(ApiResponse.fail(errorType.getCode(), errorMessage != null ? errorMessage : errorType.getMessage()));
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/interfaces/api/ApiResponse.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/interfaces/api/ApiResponse.java
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api;
+
+public record ApiResponse<T>(Metadata meta, T data) {
+    public record Metadata(Result result, String errorCode, String message) {
+        public enum Result {
+            SUCCESS, FAIL
+        }
+
+        public static Metadata success() {
+            return new Metadata(Result.SUCCESS, null, null);
+        }
+
+        public static Metadata fail(String errorCode, String errorMessage) {
+            return new Metadata(Result.FAIL, errorCode, errorMessage);
+        }
+    }
+
+    public static ApiResponse<Object> success() {
+        return new ApiResponse<>(Metadata.success(), null);
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(Metadata.success(), data);
+    }
+
+    public static ApiResponse<Object> fail(String errorCode, String errorMessage) {
+        return new ApiResponse<>(
+            Metadata.fail(errorCode, errorMessage),
+            null
+        );
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/interfaces/api/BatchV1ApiSpec.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/interfaces/api/BatchV1ApiSpec.java
@@ -1,0 +1,14 @@
+package com.loopers.interfaces.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+
+@Tag(name = "Batch API", description = "Loopers Batch API 입니다.")
+public interface BatchV1ApiSpec {
+    @Operation(
+            summary = "랭킹 배치 실행",
+            description = "랭킹 배치를 실행합니다."
+    )
+    ApiResponse<BatchV1Dto.RankingResponse> runRankingBatch(LocalDate date);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/interfaces/api/BatchV1Controller.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/interfaces/api/BatchV1Controller.java
@@ -1,0 +1,43 @@
+package com.loopers.interfaces.api;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/batch/")
+public class BatchV1Controller implements BatchV1ApiSpec {
+    private final JobLauncher jobLauncher;
+    private final Job rankingJob;
+
+    @Override
+    @PutMapping("ranking")
+    public ApiResponse<BatchV1Dto.RankingResponse> runRankingBatch(@RequestParam LocalDate date) {
+        String batchId = UUID.randomUUID().toString();
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("date", date.toString())
+                .addString("batch-id", batchId)
+                .toJobParameters();
+
+        try {
+            jobLauncher.run(rankingJob, jobParameters);
+        } catch (Exception e) {
+            log.error("배치 실패 - rankingJob", e);
+            throw new CoreException(ErrorType.INTERNAL_ERROR, "배치 실행 중 오류가 발생했습니다. Batch ID : " + batchId);
+        }
+        return ApiResponse.success(new BatchV1Dto.RankingResponse(batchId));
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/interfaces/api/BatchV1Dto.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/interfaces/api/BatchV1Dto.java
@@ -1,0 +1,8 @@
+package com.loopers.interfaces.api;
+
+public class BatchV1Dto {
+    public record RankingResponse(
+            String batchId
+    ) {
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/interfaces/scheduler/BatchScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/interfaces/scheduler/BatchScheduler.java
@@ -1,0 +1,39 @@
+package com.loopers.interfaces.scheduler;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BatchScheduler {
+    private final JobLauncher jobLauncher;
+    private final Job rankingJob;
+
+    @Scheduled(cron = "0 50 23 * * ?")
+    public void runWeeklyRankingJob() {
+        String batchId = UUID.randomUUID().toString();
+        String dateStr = LocalDate.now().toString();
+
+        log.info("배치 시작 - rankingJob - batchId: {}, date: {}", batchId, dateStr);
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("date", dateStr)
+                .addString("batch-id", batchId)
+                .toJobParameters();
+
+        try {
+            jobLauncher.run(rankingJob, jobParameters);
+        } catch (Exception e) {
+            log.error("배치 실패 - rankingJob", e);
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/support/error/CoreException.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/support/error/CoreException.java
@@ -1,0 +1,19 @@
+package com.loopers.support.error;
+
+import lombok.Getter;
+
+@Getter
+public class CoreException extends RuntimeException {
+    private final ErrorType errorType;
+    private final String customMessage;
+
+    public CoreException(ErrorType errorType) {
+        this(errorType, null);
+    }
+
+    public CoreException(ErrorType errorType, String customMessage) {
+        super(customMessage != null ? customMessage : errorType.getMessage());
+        this.errorType = errorType;
+        this.customMessage = customMessage;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/support/error/ErrorType.java
@@ -1,0 +1,19 @@
+package com.loopers.support.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorType {
+    /** 범용 에러 */
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), "일시적인 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -1,0 +1,60 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+  port: 18080
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-batch
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - logging.yml
+      - monitoring.yml
+
+  batch:
+    jdbc:
+      initialize-schema: always
+    job:
+      enabled: false
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/apps/commerce-batch/src/test/java/com/loopers/batch/job/BatchTestConfig.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/batch/job/BatchTestConfig.java
@@ -1,0 +1,18 @@
+package com.loopers.batch.job;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class BatchTestConfig {
+
+    @Bean
+    public JobLauncherTestUtils rankingJobTest(@Qualifier("rankingJob") Job job) {
+        JobLauncherTestUtils jobLauncherTestUtils = new JobLauncherTestUtils();
+        jobLauncherTestUtils.setJob(job);
+        return jobLauncherTestUtils;
+    }
+}

--- a/apps/commerce-batch/src/test/java/com/loopers/batch/job/RankingJobTest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/batch/job/RankingJobTest.java
@@ -1,0 +1,142 @@
+package com.loopers.batch.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import com.loopers.domain.ranking.DailyMetric;
+import com.loopers.domain.ranking.MonthlyProductRankMv;
+import com.loopers.domain.ranking.RankMvRepository;
+import com.loopers.domain.ranking.WeeklyProductRankMv;
+import com.loopers.infrastructure.ranking.DailyMetricJpaRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import com.loopers.utils.RedisCleanUp;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@SpringBootTest(classes = {BatchTestConfig.class})
+@SpringBatchTest
+class RankingJobTest {
+
+    @Autowired
+    @Qualifier("rankingJobTest")
+    private JobLauncherTestUtils rankingJob;
+    @Autowired
+    private DailyMetricJpaRepository dailyMetricJpaRepository;
+    @Autowired
+    private RankMvRepository rankMvRepository;
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+        redisCleanUp.truncateAll();
+    }
+
+    @Nested
+    @DisplayName("랭킹 배치 작업")
+    class WeeklyRankingJob {
+        @Test
+        @DisplayName("전체 상품 중 주간 랭킹 300위까지만 저장된다.")
+        void saveWeeklyTop300() throws Exception {
+            LocalDate date = LocalDate.of(2025, 9, 17);
+            for (long i = 1; i <= 350; i++) {
+                dailyMetricJpaRepository.save(new DailyMetric(i, 10L, 20L, 10 * i, date));
+            }
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("date", date.toString())
+                    .addString("batch-id", UUID.randomUUID().toString())
+                    .toJobParameters();
+
+            rankingJob.launchJob(jobParameters);
+
+            List<WeeklyProductRankMv> weeklyRankMv = rankMvRepository.findWeeklyRankMv(date.plusDays(1));
+            assertThat(weeklyRankMv).hasSize(300);
+        }
+
+        @Test
+        @DisplayName("각 상품의 주간 랭킹 정보가 저장된다.")
+        void saveRankingInfo() throws Exception {
+            LocalDate date = LocalDate.of(2025, 9, 17);
+            for (long i = 1; i <= 10; i++) {
+                dailyMetricJpaRepository.save(new DailyMetric(i, 10L, 20L, 10 * i, date));
+            }
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("date", date.toString())
+                    .addString("batch-id", UUID.randomUUID().toString())
+                    .toJobParameters();
+
+            rankingJob.launchJob(jobParameters);
+
+            List<WeeklyProductRankMv> weeklyRankMv = rankMvRepository.findWeeklyRankMv(date.plusDays(1));
+            assertThat(weeklyRankMv).extracting("productId", "rank")
+                    .containsExactlyInAnyOrder(tuple(10L, 1), tuple(9L, 2), tuple(8L, 3),
+                            tuple(7L, 4), tuple(6L, 5), tuple(5L, 6), tuple(4L, 7),
+                            tuple(3L, 8), tuple(2L, 9), tuple(1L, 10));
+        }
+
+        @Test
+        @DisplayName("전체 중 랭킹 300위까지만 저장된다.")
+        void saveTop300() throws Exception {
+            LocalDate date = LocalDate.of(2025, 9, 18);
+            List<WeeklyProductRankMv> weeklyMvs = new ArrayList<>();
+            for (long i = 1; i <= 350; i++) {
+                WeeklyProductRankMv mv = new WeeklyProductRankMv(i, (int) (351 - i), 1 * (double) i, date);
+                weeklyMvs.add(mv);
+            }
+            rankMvRepository.saveWeeklyRankingMvs(weeklyMvs);
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("date", date.toString())
+                    .addString("batch-id", UUID.randomUUID().toString())
+                    .toJobParameters();
+
+            rankingJob.launchJob(jobParameters);
+
+            List<MonthlyProductRankMv> monthlyRankMv = rankMvRepository.findMonthlyRankMv(date.plusDays(1));
+            MonthlyProductRankMv first = rankMvRepository.findMonthlyRankMvByProductId(date.plusDays(1), 350L).orElseThrow();
+            MonthlyProductRankMv last = rankMvRepository.findMonthlyRankMvByProductId(date.plusDays(1), 51L).orElseThrow();
+            assertThat(monthlyRankMv).hasSize(300);
+            assertThat(first.getRank()).isEqualTo(1);
+            assertThat(last.getRank()).isEqualTo(300);
+        }
+
+        @Test
+        @DisplayName("사용된 랭킹 버퍼는 삭제된다.")
+        void deleteRankingBuffer() throws Exception {
+            LocalDate date = LocalDate.of(2025, 9, 18);
+            List<WeeklyProductRankMv> weeklyMvs = new ArrayList<>();
+            for (long i = 1; i <= 10; i++) {
+                WeeklyProductRankMv mv = new WeeklyProductRankMv(i, (int) (11 - i), 1 * (double) i, date);
+                weeklyMvs.add(mv);
+            }
+            rankMvRepository.saveWeeklyRankingMvs(weeklyMvs);
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("date", date.toString())
+                    .addString("batch-id", UUID.randomUUID().toString())
+                    .toJobParameters();
+
+            rankingJob.launchJob(jobParameters);
+
+            Boolean hasKey = redisTemplate.hasKey("monthly_ranking");
+            assertThat(hasKey).isFalse();
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "loopers-commerce"
 include(
     ":apps:commerce-api",
     ":apps:commerce-streamer",
+    ":apps:commerce-batch",
     ":apps:pg-simulator",
     ":modules:jpa",
     ":modules:redis",


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

- 주간/월간 랭킹 배치 작업 추가
  - ZSet을 통한 랭킹 순위 계산
    - 주간(최근 7일) 랭킹 집계
      - 날짜별 가중치 부여 (1.0, 0.9, 0.8, 0.7, 0.4, 0.2, 0.1)
      - 날짜별 가중치가 적용되지 않은 점수도 포함하여 저장 (월간 랭킹 집계에 사용)
    - 월간(최근 30일) 랭킹 집계
      -  주차별 가중치 부여 (1주차 집계 = 1.0, 2주차 집계 = 0.8, 3주차 집계 = 0.5, 4주차 집계 = 0.2)
      - 주간 랭킹 집계를 월간 랭킹 집계에 반영하되, 주간 랭킹 가중치(날짜별 가중치)가 반영되지 않는 점수 활용
    - UPSERT 방식으로 배치가 중복되어 실행되더라도, 하나의 랭킹 정보만 저장하도록 하였습니다.
    - 시간이 부족하여 기존 ZSet 구현에서, 멘토링 때 언급해주신 DB를 통한 작업으로 수정하지 못했습니다.
- 주간/월간 랭킹 조회 API 추가

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

### 스프링 배치 구조
스프링 배치를 거의 처음 사용하다보니, 현재 작성한 배치가 괜찮은지 잘 모르겠습니다..! reader-processor-writer 구조는 멘토링 때 질문 드렸었는데, 이 외 부분에서 괜찮은지 궁금합니다.
제가 생각한 '괜찮은지'는 패키지 구조, 코드를 보았을 때 생길 수 있는 문제점이나 불편한 부분? 입니다!
현재 구조는 다음과 같습니다.
- RankingJob <- 스케쥴러가 찌름
  - Weekly
    - reader: 최근 7일 집계 기록 읽음
    - processor: 일자별 가중치 계산 ex) 5일전 0.4
    - writer: ZSet에 올림
    - listener: ZSet에서 탑 300 꺼내서 DB에 저장
  - Monthly
    - reader: 최근 4주 집계 기록 읽음 (WeeklyMv 오늘, 1주전, 2주전, 3주전 4개 읽음)
    - processor: 주차별 가중치 계산 ex) 1주전 0.8
    - writer: ZSet에 올림
    - listener: ZSet에서 탑 300 꺼내서 DB에 저장

### 스프링 배치 실패 확인
"스프링 배치를 실패했을 때, 실패 지점을 확인하고 실패 지점부터 재실행할 수 있다"라고 말씀 해주셨던 것 같습니다. 현재는 배치 실행 API를 따로 두어 수동으로 실행할 수 있게 하였습니다.
멘토링에서 언급해주신 "실패 지점부터 재실행하는 것"은 스프링 배치가 알아서 돌아가는걸까요? 그리고 실패 지점 확인은 스프링 배치가 만들어주는 테이블을 통해 직접 확인하는 것인지 궁금합니다!

### '스프링 배치를 써봤다'라는 것
멘토님은 스프링 배치를 써봤다는 사람이 만약 면접 지원자로 있을 때, 어떠한 것을 검증 또는 궁금할지 궁금합니다.
예를 들어, 카프카면은 발행 보장은 어떻게 했는지, 어떻게 멱등하게 처리했는지가 있을 것 같은데, 백엔드 개발자에게 스프링 배치는 어떠한 것을 중점으로 고려하는게 좋을까요?

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

## ✅ Checklist

### 🧱 Spring Batch

- [x]  Spring Batch Job 을 작성하고, 파라미터 기반으로 동작시킬 수 있다.
- [x]  Chunk Oriented Processing (Reader/Processor/Writer or Tasklet) 기반의 배치 처리를 구현했다.
- [x]  집계 결과를 저장할 Materialized View 의 구조를 설계하고 올바르게 적재했다.

### 🧩 Ranking API

- [x]  API 가 일간, 주간, 월간 랭킹을 제공하며 조회해야 하는 형태에 따라 적절한 데이터를 기반으로 랭킹을 제공한다.

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->